### PR TITLE
Fix auth: cache-busting, visible error messages, robust form handling

### DIFF
--- a/css/components/modals.css
+++ b/css/components/modals.css
@@ -275,12 +275,14 @@
 
 .auth-error {
     background: rgba(220, 53, 69, 0.1);
-    border: 1px solid rgba(220, 53, 69, 0.2);
+    border: 1px solid rgba(220, 53, 69, 0.3);
     color: var(--danger-color);
-    padding: var(--spacing-md);
+    padding: var(--spacing-md) var(--spacing-lg);
     border-radius: var(--radius-md);
-    margin-top: var(--spacing-lg);
-    font-size: var(--font-sm);
+    margin-bottom: var(--spacing-lg);
+    font-size: var(--font-base);
+    font-weight: 500;
+    text-align: center;
 }
 
 /* Responsive modals */

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@
     <!-- Main Stylesheet (imports all modular CSS) -->
     <link rel="stylesheet" href="css/main.css">
     
-    <!-- Preload critical resources - PROPERLY FIXED -->
-    <link rel="preload" href="js/main.js" as="script" crossorigin>
-    <link rel="preload" href="css/main.css" as="style">
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+    <meta http-equiv="Pragma" content="no-cache">
+    <meta http-equiv="Expires" content="0">
     
     <!-- Fallback for older browsers -->
     <script nomodule>

--- a/js/components/auth-modal.js
+++ b/js/components/auth-modal.js
@@ -22,6 +22,8 @@ export class AuthModal {
                 <button class="modal-close" aria-label="Sluiten">&times;</button>
             </div>
             <div class="modal-body">
+                <div class="auth-error" style="display: none;"></div>
+                
                 <div class="auth-tabs">
                     <button class="auth-tab active" data-tab="login">Inloggen</button>
                     <button class="auth-tab" data-tab="register">Registreren</button>
@@ -93,8 +95,6 @@ export class AuthModal {
                         </form>
                     </div>
                 </div>
-                
-                <div class="auth-error" style="display: none;"></div>
             </div>
         `;
         
@@ -220,22 +220,29 @@ export class AuthModal {
         const email = form.querySelector('#loginEmail').value.trim();
         const password = form.querySelector('#loginPassword').value;
         
-        if (!this.validateForm(form)) {
+        this.hideError();
+
+        if (!email || !password) {
+            this.showError('Vul alle velden in');
             return;
         }
-        
+
         this.setLoading(true);
-        this.hideError();
         
-        const result = await this.authService.login(email, password);
-        
-        this.setLoading(false);
-        
-        if (result.success) {
-            this.hide();
-            this.onAuthSuccess(result.user);
-        } else {
-            this.showError(result.error);
+        try {
+            const result = await this.authService.login(email, password);
+            
+            this.setLoading(false);
+            
+            if (result.success) {
+                this.hide();
+                this.onAuthSuccess(result.user);
+            } else {
+                this.showError(result.error);
+            }
+        } catch (error) {
+            this.setLoading(false);
+            this.showError('Er is een onverwachte fout opgetreden. Probeer het opnieuw.');
         }
     }
     
@@ -249,22 +256,48 @@ export class AuthModal {
             company: form.querySelector('#registerCompany').value.trim()
         };
         
-        if (!this.validateForm(form)) {
+        this.hideError();
+
+        if (!userData.email || !userData.password || !userData.firstName || !userData.lastName) {
+            this.showError('Vul alle verplichte velden in');
+            return;
+        }
+
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(userData.email)) {
+            this.showError('Voer een geldig e-mailadres in');
+            return;
+        }
+
+        if (userData.password.length < 8) {
+            this.showError('Wachtwoord moet minimaal 8 tekens bevatten');
+            return;
+        }
+        if (!/[A-Z]/.test(userData.password)) {
+            this.showError('Wachtwoord moet minimaal 1 hoofdletter bevatten');
+            return;
+        }
+        if (!/[0-9]/.test(userData.password)) {
+            this.showError('Wachtwoord moet minimaal 1 cijfer bevatten');
             return;
         }
         
         this.setLoading(true);
-        this.hideError();
         
-        const result = await this.authService.register(userData);
-        
-        this.setLoading(false);
-        
-        if (result.success) {
-            this.hide();
-            this.onAuthSuccess(result.user);
-        } else {
-            this.showError(result.error);
+        try {
+            const result = await this.authService.register(userData);
+            
+            this.setLoading(false);
+            
+            if (result.success) {
+                this.hide();
+                this.onAuthSuccess(result.user);
+            } else {
+                this.showError(result.error);
+            }
+        } catch (error) {
+            this.setLoading(false);
+            this.showError('Er is een onverwachte fout opgetreden. Probeer het opnieuw.');
         }
     }
     
@@ -298,6 +331,7 @@ export class AuthModal {
         const errorEl = this.modal.querySelector('.auth-error');
         errorEl.textContent = message;
         errorEl.style.display = 'block';
+        errorEl.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     }
     
     hideError() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging the previous auth PR, the login and registration buttons still appear broken:

1. **"Account aanmaken" seems to do nothing** — Validation errors (e.g., password too short, missing uppercase) were only shown as tiny inline text under individual fields, easily missed. The user sees no visible feedback.
2. **Login shows "Unexpected token '<', is not valid JSON"** — The browser had cached the old `auth-service.js` (which called `/api/auth/login`). The `fetch()` to the non-existent API returned an HTML 404 page, and `response.json()` failed trying to parse HTML.

## Changes

### `index.html`
- Added `Cache-Control`, `Pragma`, and `Expires` meta tags to prevent browsers from serving stale cached JS files
- Removed the now-unnecessary `preload` hints for source files

### `js/components/auth-modal.js`
- **Moved `.auth-error` above the form tabs** so errors are always visible at the top of the modal, not hidden below the fold
- **Replaced silent `validateForm()` gating** with explicit validation in `handleLogin()` and `handleRegister()` that calls `showError()` with clear Dutch error messages for each failing condition (empty fields, invalid email, password requirements)
- **Added try/catch** around auth service calls so unexpected errors are surfaced instead of silently swallowed
- **Added `scrollIntoView`** on the error element so users always see the message

### `css/components/modals.css`
- Made `.auth-error` more prominent: larger font, bolder, centered, with `margin-bottom` instead of `margin-top` (matching its new position above the forms)

## How to test

1. **Hard refresh** the page (Ctrl+Shift+R / Cmd+Shift+R) to clear any cached JS
2. Click "Inloggen" → switch to "Registreren" tab
3. Try submitting with empty fields → should see clear red error at top of modal
4. Try a weak password → should see specific requirement message
5. Fill all fields correctly → account is created, modal closes, header shows "Welkom, [name]"
6. Log out → log back in with the same credentials → should work

## Important note for testing

If you still see the old JSON error, please **hard refresh** (Ctrl+Shift+R) to force the browser to load the updated files. The new cache-busting meta tags will prevent this from happening again going forward.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4eec4d5-c154-4449-ab59-586350e8b1ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4eec4d5-c154-4449-ab59-586350e8b1ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

