### PR TITLE
Fix broken controls on Basis Calculator page

### DIFF
--- a/js/config/config.js
+++ b/js/config/config.js
@@ -23,7 +23,7 @@ export const Config = {
         renteLening: 10,
         looptijd: 10,
         leningLooptijd: 10,
-        rendementType: 'vast',
+        rendementType: 'maandelijks',
         rendement: 3,
         aflossingsType: 'lineair',
         herinvestering: 70,

--- a/js/main.js
+++ b/js/main.js
@@ -176,13 +176,16 @@ async initializeFeatures() {
             this.handleTabChange(tabName);
         });
         
-        // Form change handler with debouncing
         let formChangeTimeout;
+        let pendingInputs = {};
         this.formManager.onChange((inputs) => {
+            Object.assign(pendingInputs, inputs);
             clearTimeout(formChangeTimeout);
             formChangeTimeout = setTimeout(() => {
-                this.state.update({ inputs });
-            }, 300);
+                const batch = pendingInputs;
+                pendingInputs = {};
+                this.state.update({ inputs: batch });
+            }, 150);
         });
         
         // Setup feature listeners
@@ -234,14 +237,13 @@ async initializeFeatures() {
     }
     
     updateDisplays(results) {
-        // Update KPI displays
-        this.kpiDisplay.update(results);
-        
-        // Update main chart - gebruik calculator.getChartData() voor de juiste data structuur
-        const chartData = this.calculator.getChartData();
-        this.chartManager.updateMainChart(chartData);
-        
-        // Update active tab specific displays
+        const showRealValues = !!this.state.getUIState().showRealValues;
+
+        this.kpiDisplay.update(results, showRealValues);
+
+        const chartData = this.calculator.getChartData(showRealValues);
+        this.chartManager.updateMainChart(chartData, showRealValues);
+
         const activeTab = this.tabManager.getCurrentTab();
         this.updateTabDisplay(activeTab, results);
     }

--- a/js/ui/forms.js
+++ b/js/ui/forms.js
@@ -79,45 +79,38 @@ export class FormManager {
     }
     
     attachEventListeners() {
-        
         this.formElements.forEach((element, id) => {
-            // Remove any existing listeners first
-            const newElement = element.cloneNode(true);
-            element.parentNode.replaceChild(newElement, element);
-            this.formElements.set(id, newElement);
-            
-            // Attach new listeners
-            if (newElement.type === 'checkbox') {
-                newElement.addEventListener('change', (e) => {
+            if (element.type === 'checkbox') {
+                element.addEventListener('change', (e) => {
+                    this.handleChange(id, e);
+                });
+            } else if (element.tagName === 'SELECT') {
+                element.addEventListener('change', (e) => {
                     this.handleChange(id, e);
                 });
             } else {
-                // For text/number inputs, use both change and input events
-                newElement.addEventListener('change', (e) => {
+                element.addEventListener('change', (e) => {
                     this.handleChange(id, e);
                 });
-                
-                newElement.addEventListener('input', (e) => {
+                element.addEventListener('input', (e) => {
                     this.handleInput(id, e);
                 });
             }
         });
-        
-        // Special handling for tax type changes
+
         const belastingType = this.formElements.get('belastingType');
         if (belastingType) {
             belastingType.addEventListener('change', () => {
                 this.updateTaxOptionsVisibility();
             });
         }
-        
+
         const priveSubType = this.formElements.get('priveSubType');
         if (priveSubType) {
             priveSubType.addEventListener('change', () => {
                 this.updatePrivateSubTypeVisibility();
             });
         }
-        
     }
     
     handleChange(id, event) {
@@ -194,38 +187,53 @@ export class FormManager {
     updateTaxOptionsVisibility() {
         const belastingType = this.formElements.get('belastingType');
         if (!belastingType) return;
-        
+
         const taxType = belastingType.value;
-        
-        // Hide all tax options first
-        document.querySelectorAll('.tax-options').forEach(el => {
-            el.style.display = 'none';
-        });
-        
-        // Show relevant tax options
+
+        const priveOptions = document.getElementById('priveOptions');
+        if (priveOptions) {
+            priveOptions.style.display = taxType === 'prive' ? 'grid' : 'none';
+        }
+
+        if (taxType === 'prive') {
+            this.updatePrivateSubTypeVisibility();
+        }
+
         const taxOptionsId = `${taxType}Options`;
         const taxOptions = document.getElementById(taxOptionsId);
-        if (taxOptions) {
+        if (taxOptions && taxOptions.classList.contains('tax-options')) {
+            document.querySelectorAll('.tax-options').forEach(el => {
+                el.style.display = 'none';
+            });
             taxOptions.style.display = 'block';
         }
     }
-    
+
     updatePrivateSubTypeVisibility() {
         const priveSubType = this.formElements.get('priveSubType');
         if (!priveSubType) return;
-        
+
         const subType = priveSubType.value;
-        
-        // Toggle visibility of Box 1 and Box 3 options
+
         const box1Options = document.getElementById('box1Options');
         const box3Options = document.getElementById('box3Options');
-        
+        const box3TariefGroup = document.getElementById('box3TariefGroup');
+        const box3VrijstellingGroup = document.getElementById('box3VrijstellingGroup');
+
         if (box1Options) {
             box1Options.style.display = subType === 'box1' ? 'block' : 'none';
         }
-        
+
         if (box3Options) {
             box3Options.style.display = subType === 'box3' ? 'block' : 'none';
+        }
+
+        if (box3TariefGroup) {
+            box3TariefGroup.style.display = subType === 'box3' ? 'block' : 'none';
+        }
+
+        if (box3VrijstellingGroup) {
+            box3VrijstellingGroup.style.display = subType === 'box3' ? 'block' : 'none';
         }
     }
     
@@ -234,16 +242,10 @@ export class FormManager {
     }
     
     notifyListeners(changes) {
-        
-        // Handle special cases
-        if (changes.inflatieToggle !== undefined) {
-            changes.showRealValues = changes.inflatieToggle;
-            // Update state to handle UI changes
-            if (this.stateManager) {
-                this.stateManager.update({ ui: { showRealValues: changes.inflatieToggle } });
-            }
+        if (changes.inflatieToggle !== undefined && this.stateManager) {
+            this.stateManager.update({ ui: { showRealValues: changes.inflatieToggle } });
         }
-        
+
         this.listeners.forEach(listener => {
             try {
                 listener(changes);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Several controls on the **Basis Calculator** tab were either doing nothing, partially working, or silently dropping user input. This PR fixes the functionality end-to-end without altering calculation logic or other tabs.

## Bugs found (via end-to-end Puppeteer tests)

1. **Select defaults were reset on load.** `FormManager.attachEventListeners()` was cloning every form element with `cloneNode(true)` before attaching listeners. `cloneNode` copies the `selected` HTML attribute but not a programmatically assigned `.value`, so the defaults that `loadInitialValues()` had just written to the `<select>` elements were thrown away. Result:
   - `aflossingsType` reverted from `lineair` → `annuitair`
   - `priveSubType` reverted from `box3` → `box1`
   The initial calculation therefore used different loan amortization and tax settings than the configured defaults.

2. **Invalid `rendementType` default.** `Config.defaults.rendementType` was `'vast'`, which is not one of the options in the `<select>` (`maandelijks` / `jaarlijks`). The form showed `maandelijks` while state kept `'vast'`, leaving form and state out of sync until the user touched the field.

3. **Privé tax options never hid again.** `updateTaxOptionsVisibility()` queried a non-existent `.tax-options` class and `#vpbOptions` element. Switching Privé → VPB left the Privé section visible and editable.

4. **Box 3 rate/vrijstelling fields unreachable.** `updatePrivateSubTypeVisibility()` only toggled `#box1Options` and `#box3Options`, ignoring `#box3TariefGroup` and `#box3VrijstellingGroup`. Selecting Box 3 showed the fictitious return field but not the tax rate or exemption inputs.

5. **Inflation toggle ("Toon reële waardes") did nothing visible.** The checkbox updated `ui.showRealValues` in state, but `updateDisplays()` never passed that flag to `KPIDisplay.update()` or `ChartManager.updateMainChart()`. The "Reëel:" KPI subtitles stayed empty and the main chart kept plotting nominal values with the "Nominale waardes" title.

6. **Debounced form updates dropped earlier changes.** In `main.js` the debounce callback captured only the last `inputs` object emitted. When several fields changed within the 300 ms window, only the last field was applied to state. Changes are now merged into a pending batch.

## Fixes

- `js/config/config.js` — default `rendementType` to `'maandelijks'`.
- `js/ui/forms.js`
  - Attach listeners in place (no more `cloneNode`).
  - Rewrite `updateTaxOptionsVisibility()` to drive `#priveOptions` directly and re-call `updatePrivateSubTypeVisibility()` so the right Box 1 / Box 3 fields show and hide together.
  - Include `#box3TariefGroup` and `#box3VrijstellingGroup` in the Box 3 toggle logic.
  - Stop leaking a `showRealValues` key into the inputs state on toggle.
- `js/main.js`
  - `updateDisplays()` reads `ui.showRealValues` and forwards it to the KPI display and the main chart (`getChartData(showRealValues)`), so the toggle now updates both "Reëel" subtitles and the chart title.
  - Form-change debounce merges pending batches instead of overwriting them, with a slightly shorter delay for a more responsive feel.

## Testing

Ran a Puppeteer-based end-to-end suite against `npm run dev`:

- Defaults load correctly into every input / select (including aflossingsType=lineair, priveSubType=box3).
- Changing `rendement`, `rendementType`, `aflossingsType`, `startKapitaal`, etc. triggers a recalculation and updates all KPIs and the main chart.
- Inflation toggle: flipping it on/off now updates `Totaal Vermogen`, `ROI`, `Cash Reserve` subtitles with the "Reëel: …" value, and the chart title switches between "Nominale waardes" and "Reële waardes".
- Tax regime switching:
  - `VPB` → `Privé` reveals `#priveOptions`; `Privé` → `VPB` hides it again.
  - Box 1 shows only `#box1Options`; Box 3 shows `#box3Options`, `#box3TariefGroup`, `#box3VrijstellingGroup`.
  - KPIs differ between VPB / Box 1 / Box 3 as expected.
- Validation: `startKapitaal = 0` displays the error message; restoring a positive value clears it and resumes calculation.
- All other tabs (Scenario, Monte Carlo, Waterfall, Portfolio, Historisch, Opgeslagen, Export) continue to load and activate without console errors.
- `npm run build` succeeds.

No calculation logic, no other feature, and no tax module was touched.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a71d097e-d7ff-458c-86d4-a97f6b414c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a71d097e-d7ff-458c-86d4-a97f6b414c3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

