### PR TITLE
fix(export): ensure export tab buttons work reliably

### DIFF
--- a/js/features/export.js
+++ b/js/features/export.js
@@ -9,31 +9,36 @@ export class ExportFeature {
     
     setupListeners(stateManager) {
         this.stateManager = stateManager;
-        
-        // Wait for DOM to be ready
-        setTimeout(() => {
-            this.attachEventListeners();
-        }, 100);
+        this.attachEventListeners();
     }
     
     attachEventListeners() {
-        // Export buttons
+        // Buttons live inside the export tab template, which is loaded
+        // asynchronously. Attach directly when present, and idempotently mark
+        // the button so we never bind the same handler twice. activate() will
+        // re-run this once the tab becomes visible, guaranteeing the buttons
+        // are wired up regardless of load order.
         const exportButtons = {
-            'exportExcelBtn': () => this.exportToExcel(),
-            'exportPDFBtn': () => this.exportToPDF(),
-            'exportChartsBtn': () => this.exportCharts()
+            exportExcelBtn: () => this.exportToExcel(),
+            exportPDFBtn: () => this.exportToPDF(),
+            exportChartsBtn: () => this.exportCharts()
         };
         
         Object.entries(exportButtons).forEach(([id, handler]) => {
             const button = document.getElementById(id);
-            if (button) {
+            if (button && button.dataset.exportBound !== 'true') {
                 button.addEventListener('click', handler);
+                button.dataset.exportBound = 'true';
             }
         });
     }
     
     activate() {
-        // No special activation needed for export
+        // Re-attach listeners when the tab is activated. This is a safety net
+        // for cases where the template was not yet in the DOM during the
+        // initial setupListeners() call (e.g. slow networks, template
+        // hot-reload).
+        this.attachEventListeners();
     }
     
     // Export to Excel

--- a/js/main.js
+++ b/js/main.js
@@ -48,8 +48,9 @@ class ROICalculatorApp {
             // Initialize core components
             this.initializeCore();
             
-            // Initialize UI
-            this.initializeUI();
+            // Initialize UI (awaited so tab templates are in the DOM
+            // before feature modules try to attach listeners to them)
+            await this.initializeUI();
             
             // Initialize feature modules
             await this.initializeFeatures();
@@ -99,7 +100,7 @@ class ROICalculatorApp {
         this.state.loadDefaults(this.config.defaults);
     }
     
-    initializeUI() {
+    async initializeUI() {
         
         // UI Managers
         this.tabManager = new TabManager();
@@ -107,8 +108,11 @@ class ROICalculatorApp {
         this.formManager = new FormManager(this.validationService);
         this.kpiDisplay = new KPIDisplay();
         
-        // Initialize UI components with state
-        this.tabManager.initialize();
+        // Load tab templates into the DOM first. This is async (templates are
+        // fetched over the network) and *must* complete before features try to
+        // bind event listeners to elements inside those templates.
+        await this.tabManager.initialize();
+        
         this.chartManager.initialize();
         this.formManager.initialize(this.state);
         this.kpiDisplay.initialize();

--- a/js/ui/charts.js
+++ b/js/ui/charts.js
@@ -66,7 +66,7 @@ export class ChartManager {
     // Initialize main chart
     initMainChart() {
         const canvas = document.getElementById('mainChart');
-        if (!canvas) {
+        if (!canvas || typeof canvas.getContext !== 'function') {
             return;
         }
         
@@ -218,7 +218,7 @@ export class ChartManager {
     // Initialize scenario chart
     initScenarioChart() {
         const canvas = document.getElementById('scenarioChart');
-        if (!canvas) return false;
+        if (!canvas || typeof canvas.getContext !== 'function') return false;
         
         // Destroy existing chart if it exists
         if (this.charts.scenario) {
@@ -284,7 +284,7 @@ export class ChartManager {
     // Initialize portfolio chart
     initPortfolioChart() {
         const canvas = document.getElementById('portfolioChart');
-        if (!canvas) return;
+        if (!canvas || typeof canvas.getContext !== 'function') return;
         
         // Destroy existing chart if it exists
         if (this.charts.portfolio) {
@@ -337,7 +337,7 @@ export class ChartManager {
     // Initialize Monte Carlo charts
     initMonteCarloCharts() {
         const pathsCanvas = document.getElementById('monteCarloChart');
-        if (pathsCanvas) {
+        if (pathsCanvas && typeof pathsCanvas.getContext === 'function') {
             const existingChart = Chart.getChart(pathsCanvas);
             if (existingChart) {
                 existingChart.destroy();
@@ -385,7 +385,7 @@ export class ChartManager {
         }
         
         const distributionCanvas = document.getElementById('distributionChart');
-        if (distributionCanvas) {
+        if (distributionCanvas && typeof distributionCanvas.getContext === 'function') {
             const existingChart = Chart.getChart(distributionCanvas);
             if (existingChart) {
                 existingChart.destroy();
@@ -441,7 +441,7 @@ export class ChartManager {
     // Initialize waterfall chart
     initWaterfallChart() {
         const canvas = document.getElementById('waterfallChart');
-        if (!canvas) return;
+        if (!canvas || typeof canvas.getContext !== 'function') return;
         
         // Destroy existing chart if it exists
         if (this.charts.waterfall) {

--- a/public/templates/portfolio.html
+++ b/public/templates/portfolio.html
@@ -184,7 +184,7 @@
         </h3>
         
         <div class="chart-container mt-4">
-            <div id="portfolioChart"></div>
+            <canvas id="portfolioChart"></canvas>
         </div>
     </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

None of the three buttons on the Export tab (Excel, PDF, Grafieken) reliably do anything when clicked. The failure is intermittent — it reproduces consistently on deployed environments (GitHub Pages) and on anything slower than localhost.

## Root causes

There are actually two intertwined bugs:

### 1. Race condition between template loading and feature binding

`ROICalculatorApp.initializeUI()` never awaits `TabManager.initialize()`, even though that method asynchronously `fetch()`es every tab template (including `templates/export.html`) and injects them into the DOM. Because the call isn't awaited, `initializeFeatures()` runs while templates are still in flight.

`ExportFeature.setupListeners()` tried to paper over this with a 100 ms `setTimeout`, then called `document.getElementById('exportExcelBtn')` etc. On a fast localhost this mostly works; over a real network (GitHub Pages, throttled connections), the 100 ms window usually expires before the export template arrives. The three `getElementById` calls return `null`, the handlers are silently skipped, and the buttons stay inert for the entire session — no errors in the console.

Reproduced here by throttling download bandwidth to 30 kB/s with Chrome DevTools: every export button becomes permanently non-functional.

### 2. `portfolioChart` element is a `<div>`, not a `<canvas>`

`public/templates/portfolio.html` contained `<div id="portfolioChart"></div>` (the copy under `templates/` used `<canvas>` — they had drifted apart). Because Vite serves `public/` as the static root, the deployed site used the broken `<div>` version.

Once templates were properly awaited in fix #1, `ChartManager.initPortfolioChart()` called `div.getContext('2d')` and crashed with `TypeError: e.getContext is not a function`. That crash aborted the rest of `initializeUI()`, which in turn aborted `initializeFeatures()`, so _nothing_ on the page got event listeners — not just export.

## Fix

- `js/main.js`: `initializeUI()` is now `async` and awaits `tabManager.initialize()` so templates are guaranteed in the DOM before features bind.
- `js/features/export.js`: replace the fragile `setTimeout` with synchronous binding, use `dataset.exportBound` to guard against double-binding, and re-run `attachEventListeners()` from `activate()` so the tab-switch path is a safety net if binding somehow didn't happen at startup.
- `public/templates/portfolio.html`: use `<canvas id="portfolioChart">` instead of a `<div>`.
- `js/ui/charts.js`: all `init*Chart()` helpers now verify `typeof canvas.getContext === 'function'` before calling it, so a wrong-element-type regression will skip that chart instead of killing the whole app.

## Verification

Drove the deployed build end-to-end with Playwright + headless Chrome:

- Excel Downloaden → downloads `ROI_Analyse_<date>.xlsx` (valid XLSX, 79 kB, 5 sheets)
- PDF Genereren → downloads `ROI_Rapport_<date>.pdf` (valid PDF, 6 pages)
- Grafieken Downloaden → downloads 6 PNGs (`main`, `scenario`, `portfolio`, `monteCarlo`, `distribution`, `waterfall`). Before this fix only `main` was exported because `portfolio` never initialized.
- Repeated the same test with the network throttled to 30 kB/s — all three buttons still work.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b81bf25d-e37a-498e-aa96-5da2aa96cae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b81bf25d-e37a-498e-aa96-5da2aa96cae0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

