### PR TITLE
fix: restore Cashflow Waterfall tab and Multi-Asset Portfolio graphics

### DIFF
--- a/js/features/currency-portfolio.js
+++ b/js/features/currency-portfolio.js
@@ -293,14 +293,25 @@ export class CurrencyPortfolioFeature {
             
             let analysisResults;
             
-            // Check if FX Risk Analysis service is available
-            if (this.fxRiskAnalysis) {
-                analysisResults = await this.fxRiskAnalysis.analyzeCurrencyExposure(
-                    assets,
+            // The FXRiskAnalysis service exposes `analyzePortfolioExposure` and
+            // expects assets to have a `value` property (not `amount`). Only
+            // use it when both the method and historical-rate support exist;
+            // otherwise fall back to the lightweight in-feature calculation.
+            const canUseService = this.fxRiskAnalysis
+                && typeof this.fxRiskAnalysis.analyzePortfolioExposure === 'function'
+                && this.currencyService
+                && typeof this.currencyService.getHistoricalRates === 'function';
+            
+            if (canUseService) {
+                const portfolioForService = assets.map(asset => ({
+                    ...asset,
+                    value: asset.amount
+                }));
+                analysisResults = await this.fxRiskAnalysis.analyzePortfolioExposure(
+                    portfolioForService,
                     this.currencyPortfolio.baseCurrency
                 );
             } else {
-                // Fallback: Simple FX exposure calculation
                 analysisResults = await this.calculateSimpleFXExposure(assets);
             }
             
@@ -402,7 +413,7 @@ export class CurrencyPortfolioFeature {
                     </div>
                     <div class="exposure-details">
                         <span class="value">${this.formatCurrency(exposure.value, analysis.baseCurrency)}</span>
-                        <span class="assets">${exposure.assets.join(', ')}</span>
+                        <span class="assets">${this.formatExposureAssets(exposure.assets)}</span>
                     </div>
                 </div>
             `;
@@ -594,6 +605,14 @@ export class CurrencyPortfolioFeature {
         // Append to existing results
         const existingContent = resultsDiv.innerHTML;
         resultsDiv.innerHTML = existingContent + html;
+    }
+    
+    formatExposureAssets(assets) {
+        if (!Array.isArray(assets)) return '';
+        return assets
+            .map(a => (typeof a === 'string' ? a : (a && a.name) ? a.name : ''))
+            .filter(Boolean)
+            .join(', ');
     }
     
     formatCurrency(amount, currency) {

--- a/js/features/waterfall.js
+++ b/js/features/waterfall.js
@@ -216,12 +216,25 @@ export class WaterfallFeature {
             }
         });
         
+        // ChartManager may have pre-created a generic bar chart on this
+        // canvas during app init. Our waterfall uses a custom floating-bar
+        // configuration, so we must destroy any foreign chart instance first
+        // to avoid Chart.js' "Canvas is already in use" error.
+        const existingChart = typeof Chart !== 'undefined' && Chart.getChart
+            ? Chart.getChart(ctx)
+            : null;
+        if (existingChart && existingChart !== this.waterfallChart) {
+            existingChart.destroy();
+        }
+        
         // Create or update chart
         if (this.waterfallChart) {
             this.waterfallChart.data.labels = labels;
             this.waterfallChart.data.datasets[0].data = data;
             this.waterfallChart.data.datasets[0].backgroundColor = backgroundColors;
             this.waterfallChart.data.datasets[0].borderColor = borderColors;
+            this.waterfallChart.options.plugins.title.text =
+                `Cashflow Waterfall - ${this.getPeriodName(waterfallData.period)}`;
             this.waterfallChart.update();
         } else {
             this.waterfallChart = new Chart(ctx, {

--- a/public/templates/portfolio.html
+++ b/public/templates/portfolio.html
@@ -12,7 +12,16 @@
             <div class="form-group">
                 <label for="baseCurrencySelector">Basisvaluta</label>
                 <select id="baseCurrencySelector" class="currency-selector">
-                    <!-- Options populated by JavaScript -->
+                    <option value="EUR">EUR - Euro</option>
+                    <option value="USD">USD - US Dollar</option>
+                    <option value="GBP">GBP - British Pound</option>
+                    <option value="JPY">JPY - Japanese Yen</option>
+                    <option value="CHF">CHF - Swiss Franc</option>
+                    <option value="AUD">AUD - Australian Dollar</option>
+                    <option value="CAD">CAD - Canadian Dollar</option>
+                    <option value="CNY">CNY - Chinese Yuan</option>
+                    <option value="SEK">SEK - Swedish Krona</option>
+                    <option value="NZD">NZD - New Zealand Dollar</option>
                 </select>
             </div>
             <div class="form-group">
@@ -34,163 +43,102 @@
         </h3>
         
         <div id="assetList" class="asset-list">
-            <div class="asset-row" data-asset-id="default-1">
-                <div class="asset-field">
-                    <label>Asset Naam</label>
-                    <input type="text" placeholder="bijv. Amerikaanse Aandelen" class="asset-name">
-                </div>
-                <div class="asset-field">
-                    <label>Valuta</label>
-                    <select class="asset-currency currency-selector">
-                        <!-- Options populated by JavaScript -->
-                    </select>
-                </div>
-                <div class="asset-field">
-                    <label>Bedrag</label>
-                    <input type="number" placeholder="100000" class="asset-amount" min="0" step="1000">
-                    <div class="converted-value" style="display: none;"></div>
-                </div>
-                <div class="asset-field">
-                    <label>Rendement %</label>
-                    <input type="number" placeholder="7.5" class="asset-return" step="0.1">
-                </div>
-                <div class="asset-field">
-                    <label>Risico %</label>
-                    <input type="number" placeholder="15" class="asset-risk" min="0" max="100" step="1">
-                </div>
-                <button class="btn-remove" data-action="remove">×</button>
-            </div>
+            <!-- Asset rows will be dynamically added here by JavaScript -->
         </div>
         
         <div class="portfolio-controls mt-3">
-            <button class="btn btn-secondary" id="addAssetBtn">
+            <button class="btn btn-secondary" id="addAssetBtn" type="button">
                 <span class="btn-icon">➕</span>
                 Asset Toevoegen
             </button>
-            <button class="btn btn-success" id="calculatePortfolioBtn">
+            <button class="btn btn-success" id="calculatePortfolioBtn" type="button">
                 <span class="btn-icon">📊</span>
                 Portfolio Berekenen
             </button>
-            <button id="optimizePortfolioBtn" class="btn btn-primary" disabled>
+            <button id="optimizePortfolioBtn" class="btn btn-primary" disabled type="button">
                 <span class="btn-icon">📈</span>
                 Portfolio Optimaliseren
             </button>
-            <button id="savePortfolioBtn" class="btn btn-info" disabled>
+            <button id="savePortfolioBtn" class="btn btn-info" disabled type="button">
                 <span class="btn-icon">💾</span>
                 Portfolio Opslaan
             </button>
-            <button id="loadPortfolioBtn" class="btn btn-warning">
+            <button id="loadPortfolioBtn" class="btn btn-warning" type="button">
                 <span class="btn-icon">📂</span>
                 Portfolio Laden
             </button>
-            <button id="exportPortfolioBtn" class="btn btn-secondary" disabled>
-                <span class="btn-icon">📥</span>
-                Portfolio Exporteren
+            <button id="exportPortfolioBtn" class="btn btn-secondary" disabled type="button">
+                <span class="btn-icon">📤</span>
+                Exporteren
             </button>
         </div>
     </div>
     
-    <!-- Portfolio Metrics -->
-    <div class="portfolio-metrics">
+    <!-- Portfolio Results Section -->
+    <div id="portfolioResults" class="portfolio-results" style="display: none;">
         <h3 class="section-header">
             <span class="header-icon">📈</span>
-            Portfolio Prestaties
+            Portfolio Analyse
         </h3>
         
-        <div class="kpi-grid mt-4">
+        <!-- KPI Cards -->
+        <div class="kpi-cards">
             <div class="kpi-card">
-                <div class="kpi-icon">💰</div>
-                <div class="kpi-label">Portfolio Waarde</div>
-                <div class="kpi-value" id="portfolioWaarde">€ 0</div>
+                <div class="kpi-label">Totale Waarde</div>
+                <div class="kpi-value" id="portfolioWaarde">€0</div>
             </div>
-            <div class="kpi-card green">
-                <div class="kpi-icon">📈</div>
-                <div class="kpi-label">Gewogen Rendement</div>
+            <div class="kpi-card">
+                <div class="kpi-label">Verwacht Rendement</div>
                 <div class="kpi-value" id="portfolioRendement">0%</div>
             </div>
-            <div class="kpi-card orange">
-                <div class="kpi-icon">⚠️</div>
+            <div class="kpi-card">
                 <div class="kpi-label">Portfolio Risico</div>
                 <div class="kpi-value" id="portfolioRisico">0%</div>
             </div>
         </div>
-    </div>
-
-    <!-- Portfolio Results -->
-    <div id="portfolioResults" class="portfolio-results-section" style="display: none;">
-        <h3 class="section-header">
-            <span class="header-icon">📊</span>
-            Portfolio Analyse
-        </h3>
-        <div class="results-grid">
-            <div class="result-card">
-                <h4>Portfolio Metrieken</h4>
-                <div class="metric-list" id="portfolioMetrics"></div>
-            </div>
-            <div class="result-card">
-                <h4>Asset Allocatie</h4>
-                <div class="allocation-breakdown" id="allocationBreakdown"></div>
+        
+        <!-- Detailed Metrics -->
+        <div id="portfolioMetrics" class="portfolio-metrics mt-3">
+            <!-- Metrics will be populated by JavaScript -->
+        </div>
+        
+        <!-- Allocation Breakdown -->
+        <div class="allocation-section mt-4">
+            <h4>Asset Allocatie</h4>
+            <div id="allocationBreakdown" class="allocation-breakdown">
+                <!-- Allocation items will be populated by JavaScript -->
             </div>
         </div>
+        
+        <!-- Portfolio Chart -->
+        <div class="chart-section mt-4">
+            <h4>Portfolio Visualisatie</h4>
+            <div class="chart-container">
+                <canvas id="portfolioChart"></canvas>
+            </div>
+        </div>
     </div>
-
-    <!-- Currency Analysis -->
-    <div class="currency-analysis-section">
+    
+    <!-- FX Risk Analysis Section -->
+    <div class="fx-risk-section mt-4">
         <h3 class="section-header">
-            <span class="header-icon">💱</span>
-            Valuta Risico Analyse
+            <span class="header-icon">💹</span>
+            FX Risico Analyse
         </h3>
         
-        <div class="analysis-controls mt-3">
-            <button class="btn btn-primary" id="analyzeFXRiskBtn">
-                <span class="btn-icon">📊</span>
-                FX Risico Analyseren
+        <div class="fx-controls">
+            <button id="analyzeFXRiskBtn" class="btn btn-primary" type="button">
+                <span class="btn-icon">🔍</span>
+                Analyseer FX Risico
             </button>
-            <button class="btn btn-secondary" id="runStressTestBtn">
-                <span class="btn-icon">🧪</span>
-                Stresstest Uitvoeren
-            </button>
-            <button class="btn btn-success" id="calculateHedgeBtn">
-                <span class="btn-icon">🛡️</span>
-                Optimale Hedge Berekenen
+            <button id="runStressTestBtn" class="btn btn-warning" type="button">
+                <span class="btn-icon">⚡</span>
+                Stress Test
             </button>
         </div>
         
-        <div id="fxRiskAnalysisResults" class="fx-risk-results" style="display: none;">
-            <!-- Risk analysis results populated by JavaScript -->
+        <div id="fxRiskResults" class="fx-risk-results mt-3" style="display: none;">
+            <!-- FX risk analysis results will be populated here -->
         </div>
-        
-        <div id="stressTestResults" class="stress-test-results" style="display: none;">
-            <!-- Stress test results populated by JavaScript -->
-        </div>
-    </div>
-
-    <!-- Active Hedges -->
-    <div class="active-hedges-section">
-        <h3 class="section-header">
-            <span class="header-icon">🛡️</span>
-            Actieve Hedgingstrategieën
-        </h3>
-        <div id="activeHedgesContainer" class="active-hedges-container">
-            <p class="no-hedges">Geen actieve hedgingstrategieën</p>
-        </div>
-    </div>
-
-    <!-- Portfolio Visualization -->
-    <div class="portfolio-visualization">
-        <h3 class="section-header">
-            <span class="header-icon">🎯</span>
-            Asset Verdeling
-        </h3>
-        
-        <div class="chart-container mt-4">
-            <canvas id="portfolioChart"></canvas>
-        </div>
-    </div>
-
-    <!-- Loading Indicator -->
-    <div id="loadingIndicator" class="loading-indicator" style="display: none;">
-        <div class="spinner"></div>
-        <div class="loading-message">Bezig met laden...</div>
     </div>
 </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores the Cashflow Waterfall tab (the chart, table and insights were all blank) and the Multi-Asset Portfolio tab (KPI cards stayed at zero, FX risk panel never populated).

## Root causes

1. **Waterfall tab empty** — `ChartManager.initialize()` pre-creates a generic bar chart on `#waterfallChart` at app startup. When the user opens the Cashflow Waterfall tab, `WaterfallFeature.updateWaterfallChart()` tries to `new Chart(ctx, ...)` on the same canvas without destroying the existing instance, so Chart.js throws *"Canvas is already in use. Chart with ID ... must be destroyed before the canvas with ID 'waterfallChart' can be reused."* The throw aborted `update()` mid-execution, leaving the summary table, chart and insights panels empty.

2. **Multi-Asset Portfolio graphics missing** — `public/templates/portfolio.html` (the copy actually served by Vite and the production build) had drifted out of sync with `js/features/portfolio.js` and `js/features/currency-portfolio.js`:
   - A duplicate KPI grid sat outside `#portfolioResults`, so `displayResults()` populated the hidden `#portfolioResults` clone while the visible grid stayed at `€ 0` / `0%`.
   - The FX section used `id="fxRiskAnalysisResults"` / `id="stressTestResults"`, but the JS writes into `#fxRiskResults`, so FX risk analysis and stress test output never appeared.
   - `calculateHedgeBtn` had no handler.
   - The `portfolioChart` canvas lived outside the results wrapper while being duplicated elsewhere.

3. **FX Risk analysis threw** — `CurrencyPortfolioFeature.analyzeFXRisk` called `this.fxRiskAnalysis.analyzeCurrencyExposure(...)`, a method that does not exist on `FXRiskAnalysis` (the real method is `analyzePortfolioExposure` and takes assets with a `value` field, not `amount`). Clicking *Analyseer FX Risico* threw `TypeError` and the panel stayed on the *"Analyseren..."* loading state.

## Fix

- `js/features/waterfall.js`: before constructing our custom floating-bar chart, look up any chart currently bound to the canvas via `Chart.getChart()` and destroy it when it isn't ours. Also refresh the chart title when reusing the existing waterfall chart so the period label updates when the user switches periods.
- `public/templates/portfolio.html`: sync the served template with the current portfolio module layout (the root `templates/portfolio.html` was already correct).
- `js/features/currency-portfolio.js`: call `analyzePortfolioExposure` with a `value`-mapped asset copy, gate the service branch on `currencyService.getHistoricalRates` being available, and defensively render exposure asset entries whether they are strings (simple path) or full asset objects (service path).

## Validation

Reproduced both bugs against `main` with a headless-browser smoke test (loads the app, switches to Waterfall / Portfolio tabs, flips period selector, toggles percentage view, runs compare periods modal, multi-asset calculate, FX risk analysis, portfolio optimize). Before the fix the waterfall table stayed empty and Chart.js threw the canvas error; after the fix all six summary KPIs populate, six waterfall rows render, the chart exists, insights show up, period switching works, the portfolio KPI grid updates, the allocation breakdown renders three items, and the FX risk panel displays currency exposures. No console errors other than the pre-existing cross-origin warning from `api.frankfurter.app` (caught internally in `currency-service.js` which falls back to sample rates).

## Scope / risk

Three surgical changes; no behavior change in other tabs, services, or features. Template sync restores the intended layout that the portfolio JS has expected since its last rework.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cacd6a90-a030-4537-bde6-15247a11221f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cacd6a90-a030-4537-bde6-15247a11221f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

