### PR TITLE
fix(waterfall): preserve breakdown tabs and drop redundant percentage toggle

### DIFF
--- a/css/pages/waterfall.css
+++ b/css/pages/waterfall.css
@@ -267,6 +267,15 @@ input:checked + .toggle-slider:before {
     border-bottom-color: #1e3c72;
 }
 
+/* Analysis Panels - only the active panel is shown */
+.analysis-panel {
+    display: none;
+}
+
+.analysis-panel.active {
+    display: block;
+}
+
 /* Table Wrapper */
 .table-wrapper {
     overflow-x: auto;

--- a/js/features/waterfall.js
+++ b/js/features/waterfall.js
@@ -4,7 +4,7 @@ export class WaterfallFeature {
         this.calculator = calculator;
         this.chartManager = chartManager;
         this.currentPeriod = 'totaal';
-        this.showAsPercentage = false;
+        this.currentAnalysis = 'components';
         this.waterfallChart = null;
         this.trendChart = null;
     }
@@ -54,15 +54,6 @@ export class WaterfallFeature {
             periodSelect.addEventListener('change', (e) => {
                 console.log('Period changed from', this.currentPeriod, 'to', e.target.value);
                 this.currentPeriod = e.target.value;
-                this.update();
-            });
-        }
-        
-        const viewToggle = document.getElementById('waterfallViewToggle');
-        if (viewToggle) {
-            viewToggle.addEventListener('change', (e) => {
-                console.log('Percentage toggle changed to:', e.target.checked);
-                this.showAsPercentage = e.target.checked;
                 this.update();
             });
         }
@@ -314,15 +305,11 @@ export class WaterfallFeature {
                 </div>
             `;
             
-            const valueDisplay = this.showAsPercentage ? 
-                `${percentageOfBruto.toFixed(1)}%` : 
-                this.formatCurrency(item.value);
-            
             html += `
                 <tr>
                     <td>${item.label}</td>
                     <td class="${item.value < 0 ? 'negative' : item.value > 0 ? 'positive' : ''}">
-                        ${valueDisplay}
+                        ${this.formatCurrency(item.value)}
                     </td>
                     <td>${percentageOfBruto.toFixed(1)}%</td>
                     <td>${percentageOfFinal.toFixed(1)}%</td>
@@ -404,33 +391,39 @@ export class WaterfallFeature {
     }
     
     switchAnalysisTab(tabElement) {
-        // Update active state
-        document.querySelectorAll('.analysis-tab').forEach(tab => {
-            tab.classList.remove('active');
-        });
-        tabElement.classList.add('active');
-        
-        // Update content
         const analysisType = tabElement.dataset.analysis;
-        const container = document.getElementById('analysisContent');
+        if (!analysisType) return;
         
-        if (container) {
-            switch(analysisType) {
-                case 'trends':
-                    this.showTrendsAnalysis(container);
-                    break;
-                case 'ratios':
-                    this.showRatiosAnalysis(container);
-                    break;
-                default:
-                    // Components view is default
-                    this.update();
-                    break;
-            }
+        // Update active tab button
+        document.querySelectorAll('.analysis-tab').forEach(tab => {
+            tab.classList.toggle('active', tab === tabElement);
+        });
+        
+        // Show the matching panel and hide the others. Each panel keeps its
+        // own DOM so switching back to the Components view does not lose the
+        // table/chart targets rendered by update().
+        document.querySelectorAll('.analysis-panel').forEach(panel => {
+            panel.classList.toggle('active', panel.dataset.analysisPanel === analysisType);
+        });
+        
+        this.currentAnalysis = analysisType;
+        
+        switch (analysisType) {
+            case 'trends':
+                this.showTrendsAnalysis(document.getElementById('trendsPanel'));
+                break;
+            case 'ratios':
+                this.showRatiosAnalysis(document.getElementById('ratiosPanel'));
+                break;
+            case 'components':
+            default:
+                this.update();
+                break;
         }
     }
     
     showTrendsAnalysis(container) {
+        if (!container) return;
         // Get real quarterly data from calculator
         let quarters = [];
         
@@ -489,6 +482,7 @@ export class WaterfallFeature {
     }
     
     showRatiosAnalysis(container) {
+        if (!container) return;
         const waterfallData = this.getWaterfallData('totaal');
         const totals = waterfallData.totals;
         

--- a/public/templates/waterfall.html
+++ b/public/templates/waterfall.html
@@ -77,33 +77,35 @@
             <button class="analysis-tab" data-analysis="ratios">Ratio's</button>
         </div>
         
-        <div class="table-controls">
-            <div class="view-toggle">
-                <label class="toggle-switch">
-                    <input type="checkbox" id="waterfallViewToggle" aria-label="Toon percentages">
-                    <span class="toggle-slider"></span>
-                </label>
-                <span>Toon als percentages</span>
-            </div>
-        </div>
-        
         <div class="analysis-content" id="analysisContent">
             <!-- Components Table (default view) -->
-            <div class="table-wrapper">
-                <table class="cashflow-table">
-                    <thead>
-                        <tr>
-                            <th>Component</th>
-                            <th>Bedrag</th>
-                            <th>% van Bruto</th>
-                            <th>% van Totaal</th>
-                            <th>Impact</th>
-                        </tr>
-                    </thead>
-                    <tbody id="waterfallTableBody">
-                        <!-- Dynamically populated -->
-                    </tbody>
-                </table>
+            <div class="analysis-panel active" data-analysis-panel="components">
+                <div class="table-wrapper">
+                    <table class="cashflow-table">
+                        <thead>
+                            <tr>
+                                <th>Component</th>
+                                <th>Bedrag</th>
+                                <th>% van Bruto</th>
+                                <th>% van Totaal</th>
+                                <th>Impact</th>
+                            </tr>
+                        </thead>
+                        <tbody id="waterfallTableBody">
+                            <!-- Dynamically populated -->
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            
+            <!-- Trends Panel -->
+            <div class="analysis-panel" data-analysis-panel="trends" id="trendsPanel">
+                <!-- Dynamically populated on first activation -->
+            </div>
+            
+            <!-- Ratios Panel -->
+            <div class="analysis-panel" data-analysis-panel="ratios" id="ratiosPanel">
+                <!-- Dynamically populated on first activation -->
             </div>
         </div>
     </div>

--- a/templates/waterfall.html
+++ b/templates/waterfall.html
@@ -77,33 +77,35 @@
             <button class="analysis-tab" data-analysis="ratios">Ratio's</button>
         </div>
         
-        <div class="table-controls">
-            <div class="view-toggle">
-                <label class="toggle-switch">
-                    <input type="checkbox" id="waterfallViewToggle" aria-label="Toon percentages">
-                    <span class="toggle-slider"></span>
-                </label>
-                <span>Toon als percentages</span>
-            </div>
-        </div>
-        
         <div class="analysis-content" id="analysisContent">
             <!-- Components Table (default view) -->
-            <div class="table-wrapper">
-                <table class="cashflow-table">
-                    <thead>
-                        <tr>
-                            <th>Component</th>
-                            <th>Bedrag</th>
-                            <th>% van Bruto</th>
-                            <th>% van Totaal</th>
-                            <th>Impact</th>
-                        </tr>
-                    </thead>
-                    <tbody id="waterfallTableBody">
-                        <!-- Dynamically populated -->
-                    </tbody>
-                </table>
+            <div class="analysis-panel active" data-analysis-panel="components">
+                <div class="table-wrapper">
+                    <table class="cashflow-table">
+                        <thead>
+                            <tr>
+                                <th>Component</th>
+                                <th>Bedrag</th>
+                                <th>% van Bruto</th>
+                                <th>% van Totaal</th>
+                                <th>Impact</th>
+                            </tr>
+                        </thead>
+                        <tbody id="waterfallTableBody">
+                            <!-- Dynamically populated -->
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            
+            <!-- Trends Panel -->
+            <div class="analysis-panel" data-analysis-panel="trends" id="trendsPanel">
+                <!-- Dynamically populated on first activation -->
+            </div>
+            
+            <!-- Ratios Panel -->
+            <div class="analysis-panel" data-analysis-panel="ratios" id="ratiosPanel">
+                <!-- Dynamically populated on first activation -->
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two issues on the Cashflow Waterfall tab's *Cashflow Breakdown* section:

1. **Switching back to *Componenten* was impossible.** Clicking *Trends* or *Ratio's* called `container.innerHTML = ...` on `#analysisContent`, which wiped out the Components markup (including `#waterfallTableBody`). Clicking *Componenten* again ran `update()`, but `updateTable()` could no longer find the table body, so the view stayed permanently blank after the first switch away.

2. **The *Toon als percentages* toggle was redundant.** It only rewrote the *Bedrag* column to the same number already shown in the neighbouring *% van Bruto* column, adding no information.

## Fix

- Refactor the analysis content area into three sibling `.analysis-panel` elements (`components`, `trends`, `ratios`) that are shown/hidden via an `.active` class. Each panel keeps its own DOM, so switching back to any tab now works indefinitely. Trends/Ratios are still populated on first activation but write into their dedicated panel instead of the shared content wrapper.
- Remove the *Toon als percentages* toggle — the handler, the `showAsPercentage` state field, the conditional branch in `updateTable()`, and the markup. Orphan `.table-controls` / `.view-toggle` CSS is harmless and left alone to avoid touching unrelated selectors.

## Validation

Headless-browser smoke test switches Componenten → Trends → Ratio's → Componenten → Trends → Componenten and asserts:

- the active tab/panel and visibility match at every step,
- the Components table still has 6 rows whenever the Components panel is active (including after returning from Trends and Ratio's),
- Trends populates 4 quarter stats, Ratio's populates 6 ratio cards,
- the *Toon als percentages* checkbox no longer exists in the DOM,
- switching periods (Jaar 2) still works without regression.

No console errors.

## Scope / risk

Three touched files: `js/features/waterfall.js`, `templates/waterfall.html` + the served copy `public/templates/waterfall.html`, and a small CSS addition in `css/pages/waterfall.css` for `.analysis-panel` visibility. No behavior change outside the Cashflow Breakdown block.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cacd6a90-a030-4537-bde6-15247a11221f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cacd6a90-a030-4537-bde6-15247a11221f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

