### PR TITLE
Rework cashflow waterfall so components balance to Eindvermogen

### DIFF
--- a/css/pages/waterfall.css
+++ b/css/pages/waterfall.css
@@ -331,6 +331,34 @@ input:checked + .toggle-slider:before {
     font-weight: 600;
 }
 
+.cashflow-table .component-label {
+    font-weight: 600;
+    color: #212529;
+}
+
+.cashflow-table .component-description {
+    margin-top: 2px;
+    font-size: var(--font-xs);
+    color: #6c757d;
+    font-weight: 400;
+    line-height: 1.3;
+    white-space: normal;
+    max-width: 360px;
+}
+
+.cashflow-table tr.summary-row {
+    background: #f8f9fa;
+    border-top: 2px solid #dee2e6;
+}
+
+.cashflow-table tr.summary-row td {
+    font-weight: 600;
+}
+
+.cashflow-table tr.summary-row:hover {
+    background: #f1f3f5;
+}
+
 /* Impact Bar */
 .impact-bar {
     width: 80px;

--- a/js/core/calculator.js
+++ b/js/core/calculator.js
@@ -400,34 +400,73 @@ export class Calculator {
             acc.kosten += month.kosten;
             return acc;
         }, { bruttoOpbrengst: 0, belasting: 0, rente: 0, aflossing: 0, kosten: 0 });
-        
+
         const finalValue = this.data.totaalVermogen[this.data.totaalVermogen.length - 1];
-        
+
+        // The waterfall visualises the change of the investor's OWN equity
+        // over the period. Lening (loan proceeds) and aflossingen (principal
+        // repayments) cancel out on net worth - they only shift value between
+        // portfolio/cash and the outstanding debt. We therefore keep them in
+        // `totals` for informational use but deliberately leave them OUT of
+        // the flow so the bars add up to Eindvermogen.
         return {
             data: [
-                { label: 'Start Kapitaal', value: inputs.startKapitaal, type: 'start' },
-                { label: 'Lening', value: inputs.lening, type: 'positive' },
-                { label: 'Bruto Rendement', value: totals.bruttoOpbrengst, type: 'positive' },
-                { label: 'Belasting', value: -totals.belasting, type: 'negative' },
-                { label: 'Rente Kosten', value: -totals.rente, type: 'negative' },
-                { label: 'Aflossingen', value: -totals.aflossing, type: 'negative' },
-                { label: 'Vaste Kosten', value: -totals.kosten, type: 'negative' },
-                { label: 'Eindwaarde', value: finalValue, type: 'total' }
+                {
+                    label: 'Start Kapitaal',
+                    value: inputs.startKapitaal,
+                    type: 'start',
+                    description: 'Eigen inbreng aan het begin van de periode.'
+                },
+                {
+                    label: 'Bruto Rendement',
+                    value: totals.bruttoOpbrengst,
+                    type: 'positive',
+                    description: 'Rendement op de totale portefeuille (incl. eventuele lening), vóór belasting en kosten.'
+                },
+                {
+                    label: 'Belasting',
+                    value: -totals.belasting,
+                    type: 'negative',
+                    description: 'Belasting over het rendement (afhankelijk van het gekozen belastingregime).'
+                },
+                {
+                    label: 'Rentelasten',
+                    value: -totals.rente,
+                    type: 'negative',
+                    description: 'Rente betaald op de lening gedurende de periode.'
+                },
+                {
+                    label: 'Vaste Kosten',
+                    value: -totals.kosten,
+                    type: 'negative',
+                    description: 'Doorlopende vaste kosten gedurende de periode.'
+                },
+                {
+                    label: 'Eindvermogen',
+                    value: finalValue,
+                    type: 'total',
+                    description: 'Eigen vermogen aan het einde: portefeuille + cash − restschuld lening.'
+                }
             ],
             totals,
-            finalValue
+            finalValue,
+            startValue: inputs.startKapitaal,
+            loanInfo: {
+                lening: inputs.lening,
+                aflossingTotaal: totals.aflossing
+            }
         };
     }
-    
+
     getWaterfallYearPeriod(period, inputs) {
         const year = parseInt(period.replace('jaar', ''));
         const startMonth = (year - 1) * 12;
         const endMonth = Math.min(year * 12, this.data.monthlyData.length);
-        
+
         if (startMonth >= this.data.monthlyData.length) {
             return { data: [], totals: {} };
         }
-        
+
         const yearData = this.data.monthlyData.slice(startMonth, endMonth);
         const yearTotals = yearData.reduce((acc, month) => {
             acc.bruttoOpbrengst += month.bruttoOpbrengst;
@@ -437,25 +476,58 @@ export class Calculator {
             acc.kosten += month.kosten;
             return acc;
         }, { bruttoOpbrengst: 0, belasting: 0, rente: 0, aflossing: 0, kosten: 0 });
-        
+
         const startValue = year > 0 && this.data.totaalVermogen[year - 1] !== undefined
             ? this.data.totaalVermogen[year - 1]
             : inputs.startKapitaal;
-        
+
         const endValue = this.data.totaalVermogen[year] || startValue;
-        
+
         return {
             data: [
-                { label: 'Begin Saldo', value: startValue, type: 'start' },
-                { label: 'Bruto Rendement', value: yearTotals.bruttoOpbrengst, type: 'positive' },
-                { label: 'Belasting', value: -yearTotals.belasting, type: 'negative' },
-                { label: 'Rente Kosten', value: -yearTotals.rente, type: 'negative' },
-                { label: 'Aflossingen', value: -yearTotals.aflossing, type: 'negative' },
-                { label: 'Vaste Kosten', value: -yearTotals.kosten, type: 'negative' },
-                { label: 'Eind Saldo', value: endValue, type: 'total' }
+                {
+                    label: 'Beginvermogen',
+                    value: startValue,
+                    type: 'start',
+                    description: 'Eigen vermogen aan het begin van dit jaar (portefeuille + cash − restschuld lening).'
+                },
+                {
+                    label: 'Bruto Rendement',
+                    value: yearTotals.bruttoOpbrengst,
+                    type: 'positive',
+                    description: 'Rendement op de portefeuille in dit jaar, vóór belasting en kosten.'
+                },
+                {
+                    label: 'Belasting',
+                    value: -yearTotals.belasting,
+                    type: 'negative',
+                    description: 'Belasting over het rendement in dit jaar.'
+                },
+                {
+                    label: 'Rentelasten',
+                    value: -yearTotals.rente,
+                    type: 'negative',
+                    description: 'Rente betaald op de lening in dit jaar.'
+                },
+                {
+                    label: 'Vaste Kosten',
+                    value: -yearTotals.kosten,
+                    type: 'negative',
+                    description: 'Doorlopende vaste kosten in dit jaar.'
+                },
+                {
+                    label: 'Eindvermogen',
+                    value: endValue,
+                    type: 'total',
+                    description: 'Eigen vermogen aan het einde van dit jaar (portefeuille + cash − restschuld lening).'
+                }
             ],
             totals: yearTotals,
-            finalValue: endValue
+            finalValue: endValue,
+            startValue,
+            loanInfo: {
+                aflossingTotaal: yearTotals.aflossing
+            }
         };
     }
     

--- a/js/features/waterfall.js
+++ b/js/features/waterfall.js
@@ -161,6 +161,9 @@ export class WaterfallFeature {
                 return {
                     data: data.data,
                     totals: data.totals,
+                    startValue: data.startValue,
+                    finalValue: data.finalValue,
+                    loanInfo: data.loanInfo,
                     period: period
                 };
             }
@@ -168,14 +171,12 @@ export class WaterfallFeature {
 
         const mockData = {
             data: [
-                { label: 'Start Kapitaal', value: 100000, type: 'start' },
-                { label: 'Lening', value: 50000, type: 'positive' },
-                { label: 'Bruto Rendement', value: 15000, type: 'positive' },
-                { label: 'Belasting', value: -3750, type: 'negative' },
-                { label: 'Rente Kosten', value: -2500, type: 'negative' },
-                { label: 'Aflossingen', value: -10000, type: 'negative' },
-                { label: 'Vaste Kosten', value: -1200, type: 'negative' },
-                { label: 'Eindwaarde', value: 147550, type: 'total' }
+                { label: 'Start Kapitaal', value: 100000, type: 'start', description: 'Eigen inbreng aan het begin van de periode.' },
+                { label: 'Bruto Rendement', value: 15000, type: 'positive', description: 'Rendement op de totale portefeuille, vóór belasting en kosten.' },
+                { label: 'Belasting', value: -3750, type: 'negative', description: 'Belasting over het rendement.' },
+                { label: 'Rentelasten', value: -2500, type: 'negative', description: 'Rente betaald op de lening.' },
+                { label: 'Vaste Kosten', value: -1200, type: 'negative', description: 'Doorlopende vaste kosten.' },
+                { label: 'Eindvermogen', value: 107550, type: 'total', description: 'Eigen vermogen aan het einde van de periode.' }
             ],
             totals: {
                 bruttoOpbrengst: 15000,
@@ -184,37 +185,55 @@ export class WaterfallFeature {
                 aflossing: 10000,
                 kosten: 1200
             },
+            startValue: 100000,
+            finalValue: 107550,
+            loanInfo: { lening: 50000, aflossingTotaal: 10000 },
             period: period
         };
 
         return mockData;
     }
 
+    /**
+     * Summary metrics are derived directly from the equity-waterfall identity:
+     *   ΔEigen Vermogen = Bruto Rendement − Belasting − Rente − Vaste Kosten
+     * Aflossingen (principal repayments) are deliberately excluded - they
+     * shift value between cash and debt but do not change equity, so mixing
+     * them into "uitgaven" makes the cards inconsistent with the chart.
+     */
     updateSummaryCards(totals) {
-        const bruttoInkomsten = totals.bruttoOpbrengst || 0;
+        const bruto = totals.bruttoOpbrengst || 0;
         const belasting = totals.belasting || 0;
-        const uitgaven = (totals.rente || 0) + (totals.aflossing || 0) + (totals.kosten || 0);
-        const nettoInkomsten = bruttoInkomsten - belasting;
-        const netto = nettoInkomsten - uitgaven;
-        const cashflowRatio = bruttoInkomsten > 0 ? (netto / bruttoInkomsten) * 100 : 0;
-        const belastingTarief = bruttoInkomsten > 0 ? (belasting / bruttoInkomsten) * 100 : 0;
+        const rente = totals.rente || 0;
+        const kosten = totals.kosten || 0;
 
-        this.updateElement('wfTotaleInkomsten', this.formatCurrency(nettoInkomsten));
-        this.updateElement('wfInkomstenDetail', `Bruto: ${this.formatCurrency(bruttoInkomsten)} | Belasting: ${this.formatCurrency(belasting)}`);
+        const kostenTotaal = rente + kosten;
+        const nettoResultaat = bruto - belasting - kostenTotaal;
+        const efficientie = bruto > 0 ? (nettoResultaat / bruto) * 100 : 0;
+        const belastingTarief = bruto > 0 ? (belasting / bruto) * 100 : 0;
 
-        this.updateElement('wfTotaleUitgaven', this.formatCurrency(uitgaven));
-        this.updateElement('wfUitgavenDetail', `Rente: ${this.formatCurrency(totals.rente || 0)} | Aflossing: ${this.formatCurrency(totals.aflossing || 0)} | Kosten: ${this.formatCurrency(totals.kosten || 0)}`);
+        this.updateElement('wfBrutoRendement', this.formatCurrency(bruto));
+        this.updateElement('wfBrutoRendementDetail', 'Vóór belasting, rente en kosten');
 
-        this.updateElement('wfNettoCashflow', this.formatCurrency(netto));
-        this.updateElement('wfCashflowDetail', `${cashflowRatio.toFixed(1)}% van bruto inkomsten`);
+        this.updateElement('wfKostenTotaal', this.formatCurrency(kostenTotaal));
+        this.updateElement('wfKostenDetail', `Rente: ${this.formatCurrency(rente)} | Vaste kosten: ${this.formatCurrency(kosten)}`);
+
+        this.updateElement('wfNettoResultaat', this.formatCurrency(nettoResultaat));
+        this.updateElement('wfNettoResultaatDetail',
+            `${efficientie.toFixed(1)}% van bruto · verandert het eigen vermogen`);
 
         this.updateElement('wfBelastingTarief', `${belastingTarief.toFixed(1)}%`);
-        this.updateElement('wfBelastingDetail', 'Op bruto rendement');
+        this.updateElement('wfBelastingDetail', `Belasting ${this.formatCurrency(belasting)} op bruto rendement`);
     }
 
     updateWaterfallChart(waterfallData) {
         const ctx = document.getElementById('waterfallChart');
         if (!ctx) return;
+
+        // Keep the latest waterfall data available to the tooltip callbacks,
+        // which are bound once at chart creation and otherwise would hold on
+        // to a stale closure when only the dataset is updated.
+        this.currentWaterfallData = waterfallData;
 
         const labels = [];
         const data = [];
@@ -297,11 +316,30 @@ export class WaterfallFeature {
                         },
                         tooltip: {
                             callbacks: {
+                                title: (items) => {
+                                    if (!items || !items.length) return '';
+                                    return items[0].label || '';
+                                },
                                 label: (context) => {
-                                    const value = context.parsed.y;
-                                    const start = context.parsed.x || 0;
-                                    const diff = value - start;
-                                    return `${this.formatCurrency(Math.abs(diff))}`;
+                                    const current = this.currentWaterfallData;
+                                    const item = current && current.data
+                                        ? current.data[context.dataIndex]
+                                        : null;
+                                    if (!item) return this.formatCurrency(0);
+
+                                    if (item.type === 'start' || item.type === 'total') {
+                                        return this.formatCurrency(item.value);
+                                    }
+
+                                    const sign = item.value >= 0 ? '+' : '−';
+                                    return `${sign} ${this.formatCurrency(Math.abs(item.value))}`;
+                                },
+                                afterLabel: (context) => {
+                                    const current = this.currentWaterfallData;
+                                    const item = current && current.data
+                                        ? current.data[context.dataIndex]
+                                        : null;
+                                    return item && item.description ? item.description : '';
                                 }
                             }
                         }
@@ -323,9 +361,13 @@ export class WaterfallFeature {
         const tbody = document.getElementById('waterfallTableBody');
         if (!tbody) return;
 
-        const totals = waterfallData.totals;
-        const bruttoInkomsten = totals.bruttoOpbrengst || 1;
-        const finalValue = waterfallData.data[waterfallData.data.length - 1].value || 1;
+        const totals = waterfallData.totals || {};
+        const bruto = Math.max(totals.bruttoOpbrengst || 0, 0);
+
+        // Use bruto rendement as the reference for share-of calculations. It
+        // represents the income that is being divided over tax, interest,
+        // costs and what is left as net equity growth.
+        const referenceValue = bruto > 0 ? bruto : 1;
 
         let html = '';
 
@@ -333,10 +375,9 @@ export class WaterfallFeature {
             if (item.type === 'start' || item.type === 'total') return;
 
             const absValue = Math.abs(item.value);
-            const percentageOfBruto = (absValue / bruttoInkomsten) * 100;
-            const percentageOfFinal = (absValue / finalValue) * 100;
-
+            const percentageOfBruto = bruto > 0 ? (absValue / referenceValue) * 100 : 0;
             const impactWidth = Math.min(percentageOfBruto, 100);
+
             const impactBar = `
                 <div class="impact-bar" role="progressbar" aria-valuenow="${impactWidth.toFixed(0)}" aria-valuemin="0" aria-valuemax="100">
                     <div class="impact-bar-fill ${item.value >= 0 ? 'positive' : 'negative'}"
@@ -344,18 +385,45 @@ export class WaterfallFeature {
                 </div>
             `;
 
+            const description = item.description
+                ? `<div class="component-description">${item.description}</div>`
+                : '';
+
             html += `
                 <tr>
-                    <td>${item.label}</td>
+                    <td>
+                        <div class="component-label">${item.label}</div>
+                        ${description}
+                    </td>
                     <td class="${item.value < 0 ? 'negative' : item.value > 0 ? 'positive' : ''}">
                         ${this.formatCurrency(item.value)}
                     </td>
-                    <td>${percentageOfBruto.toFixed(1)}%</td>
-                    <td>${percentageOfFinal.toFixed(1)}%</td>
+                    <td>${bruto > 0 ? percentageOfBruto.toFixed(1) + '%' : '—'}</td>
                     <td>${impactBar}</td>
                 </tr>
             `;
         });
+
+        // Append a summary row that makes the equity identity explicit so
+        // readers can verify that the components balance to the change in
+        // eigen vermogen for the selected period.
+        const startValue = waterfallData.startValue;
+        const finalValue = waterfallData.finalValue;
+        if (typeof startValue === 'number' && typeof finalValue === 'number') {
+            const delta = finalValue - startValue;
+            const deltaClass = delta >= 0 ? 'positive' : 'negative';
+            html += `
+                <tr class="summary-row">
+                    <td>
+                        <div class="component-label">Δ Eigen Vermogen</div>
+                        <div class="component-description">Eindvermogen − Beginvermogen (moet gelijk zijn aan bruto − belasting − rente − kosten).</div>
+                    </td>
+                    <td class="${deltaClass}">${this.formatCurrency(delta)}</td>
+                    <td>—</td>
+                    <td></td>
+                </tr>
+            `;
+        }
 
         tbody.innerHTML = html;
     }
@@ -369,20 +437,22 @@ export class WaterfallFeature {
         const bruttoInkomsten = totals.bruttoOpbrengst || 0;
         const belasting = totals.belasting || 0;
         const rente = totals.rente || 0;
-        const aflossing = totals.aflossing || 0;
         const kosten = totals.kosten || 0;
-        const netto = bruttoInkomsten - belasting - rente - aflossing - kosten;
+        // Netto hier = verandering in eigen vermogen door de flow componenten.
+        // Aflossingen veranderen eigen vermogen niet en worden daarom niet
+        // afgetrokken (zie waterfall data model).
+        const netto = bruttoInkomsten - belasting - rente - kosten;
 
         const efficiency = bruttoInkomsten > 0 ? (netto / bruttoInkomsten) * 100 : 0;
         if (efficiency > 50) {
             insights.push({
                 type: 'success',
-                text: `Uitstekende cashflow efficiëntie: ${efficiency.toFixed(1)}% van bruto rendement blijft over als netto cashflow.`
+                text: `Sterke netto marge: ${efficiency.toFixed(1)}% van het bruto rendement groeit door naar het eigen vermogen (na belasting, rente en vaste kosten).`
             });
         } else if (efficiency < 20 && bruttoInkomsten > 0) {
             insights.push({
                 type: 'warning',
-                text: `Lage cashflow efficiëntie: slechts ${efficiency.toFixed(1)}% van bruto rendement blijft over. Overweeg kostenoptimalisatie.`
+                text: `Lage netto marge: slechts ${efficiency.toFixed(1)}% van het bruto rendement blijft over na belasting, rente en kosten. Overweeg kostenoptimalisatie.`
             });
         }
 
@@ -579,40 +649,43 @@ export class WaterfallFeature {
     }
 
     calculateRatios(totals) {
-        const bruttoInkomsten = totals.bruttoOpbrengst || 1;
-        const nettoInkomsten = bruttoInkomsten - (totals.belasting || 0);
-        const totaleKosten = (totals.rente || 0) + (totals.aflossing || 0) + (totals.kosten || 0);
+        const bruto = totals.bruttoOpbrengst || 1;
+        const belasting = totals.belasting || 0;
+        const rente = totals.rente || 0;
+        const kosten = totals.kosten || 0;
+        const nettoNaBelasting = bruto - belasting;
+        const nettoResultaat = nettoNaBelasting - rente - kosten;
 
         return [
             {
-                label: 'Cashflow Conversie',
-                value: ((nettoInkomsten - totaleKosten) / bruttoInkomsten * 100).toFixed(1) + '%',
-                description: 'Netto cashflow als % van bruto'
+                label: 'Netto Marge',
+                value: (nettoResultaat / bruto * 100).toFixed(1) + '%',
+                description: 'Eigen vermogensgroei (bruto − belasting − rente − kosten) als % van bruto rendement'
             },
             {
                 label: 'Belastingdruk',
-                value: ((totals.belasting || 0) / bruttoInkomsten * 100).toFixed(1) + '%',
-                description: 'Belasting als % van bruto'
+                value: (belasting / bruto * 100).toFixed(1) + '%',
+                description: 'Belasting als % van bruto rendement'
             },
             {
                 label: 'Rentelast',
-                value: ((totals.rente || 0) / bruttoInkomsten * 100).toFixed(1) + '%',
-                description: 'Rente als % van bruto'
+                value: (rente / bruto * 100).toFixed(1) + '%',
+                description: 'Rente op lening als % van bruto rendement'
             },
             {
                 label: 'Kostenratio',
-                value: ((totals.kosten || 0) / bruttoInkomsten * 100).toFixed(1) + '%',
-                description: 'Vaste kosten als % van bruto'
+                value: (kosten / bruto * 100).toFixed(1) + '%',
+                description: 'Vaste kosten als % van bruto rendement'
             },
             {
-                label: 'Operationele Efficiëntie',
-                value: (nettoInkomsten / bruttoInkomsten * 100).toFixed(1) + '%',
-                description: 'Netto na belasting als % van bruto'
+                label: 'Netto na Belasting',
+                value: (nettoNaBelasting / bruto * 100).toFixed(1) + '%',
+                description: 'Rendement na belasting als % van bruto'
             },
             {
-                label: 'Financieringsdruk',
-                value: (((totals.rente || 0) + (totals.aflossing || 0)) / bruttoInkomsten * 100).toFixed(1) + '%',
-                description: 'Totale financiering als % van bruto'
+                label: 'Totale Kostenratio',
+                value: ((belasting + rente + kosten) / bruto * 100).toFixed(1) + '%',
+                description: 'Belasting + rente + kosten als % van bruto rendement'
             }
         ];
     }
@@ -695,8 +768,12 @@ export class WaterfallFeature {
                 const data = this.getWaterfallData(period);
                 const totals = data.totals || {};
                 const bruto = totals.bruttoOpbrengst || 0;
+                // Efficiency here reflects how much of the bruto rendement
+                // actually ends up as growth in eigen vermogen. Aflossingen
+                // do not belong in this ratio (they shift value between cash
+                // and debt without changing equity).
                 const efficiency = bruto > 0
-                    ? ((bruto - (totals.belasting || 0) - (totals.rente || 0) - (totals.aflossing || 0) - (totals.kosten || 0)) / bruto) * 100
+                    ? ((bruto - (totals.belasting || 0) - (totals.rente || 0) - (totals.kosten || 0)) / bruto) * 100
                     : 0;
                 return {
                     period: this.getPeriodName(period),
@@ -733,12 +810,11 @@ export class WaterfallFeature {
                             <thead>
                                 <tr>
                                     <th>Periode</th>
-                                    <th>Bruto Rendement</th>
+                                    <th title="Rendement op de totale portefeuille (incl. lening), vóór belasting en kosten">Bruto Rendement</th>
                                     <th>Belasting</th>
                                     <th>Rente</th>
-                                    <th>Aflossing</th>
-                                    <th>Kosten</th>
-                                    <th>Efficiëntie</th>
+                                    <th>Vaste Kosten</th>
+                                    <th title="(Bruto − Belasting − Rente − Kosten) / Bruto">Netto Marge</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -748,7 +824,6 @@ export class WaterfallFeature {
                                         <td>${this.formatCurrency(period.totals.bruttoOpbrengst || 0)}</td>
                                         <td class="negative">${this.formatCurrency(period.totals.belasting || 0)}</td>
                                         <td class="negative">${this.formatCurrency(period.totals.rente || 0)}</td>
-                                        <td class="negative">${this.formatCurrency(period.totals.aflossing || 0)}</td>
                                         <td class="negative">${this.formatCurrency(period.totals.kosten || 0)}</td>
                                         <td class="${period.efficiency > 50 ? 'positive' : period.efficiency < 20 ? 'negative' : ''}">${period.efficiency.toFixed(1)}%</td>
                                     </tr>
@@ -835,9 +910,8 @@ export class WaterfallFeature {
         const bruttoInkomsten = totals.bruttoOpbrengst || 0;
         const belasting = totals.belasting || 0;
         const rente = totals.rente || 0;
-        const aflossing = totals.aflossing || 0;
         const kosten = totals.kosten || 0;
-        const netto = bruttoInkomsten - belasting - rente - aflossing - kosten;
+        const netto = bruttoInkomsten - belasting - rente - kosten;
 
         return {
             efficiency: bruttoInkomsten > 0 ? (netto / bruttoInkomsten) * 100 : 0,

--- a/public/templates/waterfall.html
+++ b/public/templates/waterfall.html
@@ -1,7 +1,10 @@
 <section id="waterfall" class="tab-pane" role="tabpanel">
     <h2>💧 Cashflow Waterfall Analyse</h2>
-    <p class="tab-description">Gedetailleerd overzicht van alle geldstromen per periode met visuele breakdown</p>
-    
+    <p class="tab-description">
+        Van <strong>Start Kapitaal</strong> via <strong>Bruto Rendement</strong>, minus belasting, rente en vaste kosten,
+        naar <strong>Eindvermogen</strong>. De componenten tellen exact op tot de verandering in eigen vermogen over de periode.
+    </p>
+
     <!-- Controls Section -->
     <div class="waterfall-controls">
         <div class="period-selector-group">
@@ -23,51 +26,51 @@
             </button>
         </div>
     </div>
-    
+
     <!-- Summary Cards -->
     <div class="waterfall-summary">
         <div class="summary-card positive">
             <div class="summary-icon">📈</div>
             <div class="summary-content">
-                <div class="summary-label">Totale Inkomsten</div>
-                <div class="summary-value" id="wfTotaleInkomsten">€ 0</div>
-                <div class="summary-detail" id="wfInkomstenDetail">Bruto: € 0 | Belasting: € 0</div>
+                <div class="summary-label">Bruto Rendement</div>
+                <div class="summary-value" id="wfBrutoRendement">€ 0</div>
+                <div class="summary-detail" id="wfBrutoRendementDetail">Vóór belasting, rente en kosten</div>
             </div>
         </div>
-        
+
         <div class="summary-card negative">
             <div class="summary-icon">📉</div>
             <div class="summary-content">
-                <div class="summary-label">Totale Uitgaven</div>
-                <div class="summary-value" id="wfTotaleUitgaven">€ 0</div>
-                <div class="summary-detail" id="wfUitgavenDetail">Rente: € 0 | Aflossing: € 0 | Kosten: € 0</div>
+                <div class="summary-label">Kosten (rente + vaste kosten)</div>
+                <div class="summary-value" id="wfKostenTotaal">€ 0</div>
+                <div class="summary-detail" id="wfKostenDetail">Rente: € 0 | Vaste kosten: € 0</div>
             </div>
         </div>
-        
+
         <div class="summary-card primary">
             <div class="summary-icon">💰</div>
             <div class="summary-content">
-                <div class="summary-label">Netto Cashflow</div>
-                <div class="summary-value" id="wfNettoCashflow">€ 0</div>
-                <div class="summary-detail" id="wfCashflowDetail">0% van bruto inkomsten</div>
+                <div class="summary-label">Netto Resultaat</div>
+                <div class="summary-value" id="wfNettoResultaat">€ 0</div>
+                <div class="summary-detail" id="wfNettoResultaatDetail">0% van bruto · verandert het eigen vermogen</div>
             </div>
         </div>
-        
+
         <div class="summary-card info">
             <div class="summary-icon">📊</div>
             <div class="summary-content">
                 <div class="summary-label">Effectief Belastingtarief</div>
                 <div class="summary-value" id="wfBelastingTarief">0%</div>
-                <div class="summary-detail" id="wfBelastingDetail">Op bruto rendement</div>
+                <div class="summary-detail" id="wfBelastingDetail">Belasting € 0 op bruto rendement</div>
             </div>
         </div>
     </div>
-    
+
     <!-- Main Waterfall Chart -->
     <div class="chart-container tall mt-4">
         <canvas id="waterfallChart"></canvas>
     </div>
-    
+
     <!-- Analysis Section -->
     <div class="waterfall-analysis mt-4">
         <h3>📊 Cashflow Breakdown</h3>
@@ -76,7 +79,7 @@
             <button type="button" class="analysis-tab" data-analysis="trends" role="tab" aria-selected="false">Trends</button>
             <button type="button" class="analysis-tab" data-analysis="ratios" role="tab" aria-selected="false">Ratio's</button>
         </div>
-        
+
         <div class="analysis-content" id="analysisContent">
             <!-- Components Table (default view) -->
             <div class="analysis-panel active" data-analysis-panel="components">
@@ -86,8 +89,7 @@
                             <tr>
                                 <th>Component</th>
                                 <th>Bedrag</th>
-                                <th>% van Bruto</th>
-                                <th>% van Totaal</th>
+                                <th title="Aandeel van het bruto rendement">% van Bruto</th>
                                 <th>Impact</th>
                             </tr>
                         </thead>
@@ -97,19 +99,19 @@
                     </table>
                 </div>
             </div>
-            
+
             <!-- Trends Panel -->
             <div class="analysis-panel" data-analysis-panel="trends" id="trendsPanel">
                 <!-- Dynamically populated on first activation -->
             </div>
-            
+
             <!-- Ratios Panel -->
             <div class="analysis-panel" data-analysis-panel="ratios" id="ratiosPanel">
                 <!-- Dynamically populated on first activation -->
             </div>
         </div>
     </div>
-    
+
     <!-- Insights Section -->
     <div class="waterfall-insights mt-4">
         <h3>💡 Inzichten & Aanbevelingen</h3>
@@ -117,7 +119,7 @@
             <!-- Dynamically populated insights -->
         </div>
     </div>
-    
+
     <!-- Mobile Hint -->
     <div class="mobile-table-hint mt-2">
         💡 Tip: Swipe de tabel horizontaal om alle kolommen te zien

--- a/templates/waterfall.html
+++ b/templates/waterfall.html
@@ -1,7 +1,10 @@
 <section id="waterfall" class="tab-pane" role="tabpanel">
     <h2>💧 Cashflow Waterfall Analyse</h2>
-    <p class="tab-description">Gedetailleerd overzicht van alle geldstromen per periode met visuele breakdown</p>
-    
+    <p class="tab-description">
+        Van <strong>Start Kapitaal</strong> via <strong>Bruto Rendement</strong>, minus belasting, rente en vaste kosten,
+        naar <strong>Eindvermogen</strong>. De componenten tellen exact op tot de verandering in eigen vermogen over de periode.
+    </p>
+
     <!-- Controls Section -->
     <div class="waterfall-controls">
         <div class="period-selector-group">
@@ -23,51 +26,51 @@
             </button>
         </div>
     </div>
-    
+
     <!-- Summary Cards -->
     <div class="waterfall-summary">
         <div class="summary-card positive">
             <div class="summary-icon">📈</div>
             <div class="summary-content">
-                <div class="summary-label">Totale Inkomsten</div>
-                <div class="summary-value" id="wfTotaleInkomsten">€ 0</div>
-                <div class="summary-detail" id="wfInkomstenDetail">Bruto: € 0 | Belasting: € 0</div>
+                <div class="summary-label">Bruto Rendement</div>
+                <div class="summary-value" id="wfBrutoRendement">€ 0</div>
+                <div class="summary-detail" id="wfBrutoRendementDetail">Vóór belasting, rente en kosten</div>
             </div>
         </div>
-        
+
         <div class="summary-card negative">
             <div class="summary-icon">📉</div>
             <div class="summary-content">
-                <div class="summary-label">Totale Uitgaven</div>
-                <div class="summary-value" id="wfTotaleUitgaven">€ 0</div>
-                <div class="summary-detail" id="wfUitgavenDetail">Rente: € 0 | Aflossing: € 0 | Kosten: € 0</div>
+                <div class="summary-label">Kosten (rente + vaste kosten)</div>
+                <div class="summary-value" id="wfKostenTotaal">€ 0</div>
+                <div class="summary-detail" id="wfKostenDetail">Rente: € 0 | Vaste kosten: € 0</div>
             </div>
         </div>
-        
+
         <div class="summary-card primary">
             <div class="summary-icon">💰</div>
             <div class="summary-content">
-                <div class="summary-label">Netto Cashflow</div>
-                <div class="summary-value" id="wfNettoCashflow">€ 0</div>
-                <div class="summary-detail" id="wfCashflowDetail">0% van bruto inkomsten</div>
+                <div class="summary-label">Netto Resultaat</div>
+                <div class="summary-value" id="wfNettoResultaat">€ 0</div>
+                <div class="summary-detail" id="wfNettoResultaatDetail">0% van bruto · verandert het eigen vermogen</div>
             </div>
         </div>
-        
+
         <div class="summary-card info">
             <div class="summary-icon">📊</div>
             <div class="summary-content">
                 <div class="summary-label">Effectief Belastingtarief</div>
                 <div class="summary-value" id="wfBelastingTarief">0%</div>
-                <div class="summary-detail" id="wfBelastingDetail">Op bruto rendement</div>
+                <div class="summary-detail" id="wfBelastingDetail">Belasting € 0 op bruto rendement</div>
             </div>
         </div>
     </div>
-    
+
     <!-- Main Waterfall Chart -->
     <div class="chart-container tall mt-4">
         <canvas id="waterfallChart"></canvas>
     </div>
-    
+
     <!-- Analysis Section -->
     <div class="waterfall-analysis mt-4">
         <h3>📊 Cashflow Breakdown</h3>
@@ -76,7 +79,7 @@
             <button type="button" class="analysis-tab" data-analysis="trends" role="tab" aria-selected="false">Trends</button>
             <button type="button" class="analysis-tab" data-analysis="ratios" role="tab" aria-selected="false">Ratio's</button>
         </div>
-        
+
         <div class="analysis-content" id="analysisContent">
             <!-- Components Table (default view) -->
             <div class="analysis-panel active" data-analysis-panel="components">
@@ -86,8 +89,7 @@
                             <tr>
                                 <th>Component</th>
                                 <th>Bedrag</th>
-                                <th>% van Bruto</th>
-                                <th>% van Totaal</th>
+                                <th title="Aandeel van het bruto rendement">% van Bruto</th>
                                 <th>Impact</th>
                             </tr>
                         </thead>
@@ -97,19 +99,19 @@
                     </table>
                 </div>
             </div>
-            
+
             <!-- Trends Panel -->
             <div class="analysis-panel" data-analysis-panel="trends" id="trendsPanel">
                 <!-- Dynamically populated on first activation -->
             </div>
-            
+
             <!-- Ratios Panel -->
             <div class="analysis-panel" data-analysis-panel="ratios" id="ratiosPanel">
                 <!-- Dynamically populated on first activation -->
             </div>
         </div>
     </div>
-    
+
     <!-- Insights Section -->
     <div class="waterfall-insights mt-4">
         <h3>💡 Inzichten & Aanbevelingen</h3>
@@ -117,7 +119,7 @@
             <!-- Dynamically populated insights -->
         </div>
     </div>
-    
+
     <!-- Mobile Hint -->
     <div class="mobile-table-hint mt-2">
         💡 Tip: Swipe de tabel horizontaal om alle kolommen te zien


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

On the **Cashflow Waterfall** tab, the breakdown (components table) and the main waterfall chart showed a flow of `Start Kapitaal → +Lening → +Bruto Rendement → −Belasting → −Rente → −Aflossingen → −Vaste Kosten → Eindwaarde`. Readers had to make assumptions about what those bars actually represented because the math did not balance in the general case:

- `Lening` is added to the starting portfolio **and** booked as debt → it is a wash on *eigen vermogen*.
- `Aflossingen` reduces cash **and** reduces the outstanding loan → also a wash on *eigen vermogen*.

The cumulative bars only matched `Eindwaarde` by coincidence when the loan fully amortised inside the investment horizon. In other common cases (e.g. `leningLooptijd > looptijd`, or `aflossingsvrij`) the chart visibly failed to balance. On top of that, the summary cards mixed `aflossing` into *Totale Uitgaven* even though it is a debt transfer, not a cost, which doubled down on the confusion.

`Bruto Rendement` was also ambiguous: it was computed on the *leveraged* portfolio (eigen kapitaal + lening) and before belasting/kosten, but none of that was visible from the label alone.

## What changed

### `js/core/calculator.js`
- `getWaterfallTotalPeriod` / `getWaterfallYearPeriod` now emit a pure **equity waterfall**: `Start Kapitaal → Bruto Rendement → Belasting → Rentelasten → Vaste Kosten → Eindvermogen`.
- Every step carries a human readable `description`, and the payload now also exposes `startValue`, `finalValue` and `loanInfo` (loan proceeds and total repayments) so callers can still surface that information without mixing it into the equity flow.
- `Aflossingen` and the initial `Lening` are preserved in `totals` / `loanInfo` (needed for exports, ratios, etc.) but are deliberately left out of the flow, so the bars now exactly sum to the change in eigen vermogen.

### `js/features/waterfall.js`
- Summary cards reworked to `Bruto Rendement`, `Kosten (rente + vaste kosten)`, `Netto Resultaat`, `Effectief Belastingtarief` — all directly traceable from the chart.
- Table renders a description per component and an explicit **Δ Eigen Vermogen** summary row that makes the identity `Bruto − Belasting − Rente − Kosten = Δ Eigen Vermogen` visible to the reader.
- Chart.js tooltip now shows the component label, a signed amount and the description.
- Ratios (`Netto Marge`, `Belastingdruk`, `Rentelast`, `Kostenratio`, `Netto na Belasting`, `Totale Kostenratio`) were reworded to stop double-counting aflossing.
- Period comparison modal dropped the `Aflossing` column and renamed `Efficiëntie` → `Netto Marge` with a tooltip describing how it is computed.
- Insight copy now talks about *netto marge* instead of *cashflow efficiency* so it matches the new vocabulary.

### Templates (`templates/waterfall.html` + `public/templates/waterfall.html`)
- New summary card IDs (`wfBrutoRendement`, `wfKostenTotaal`, `wfNettoResultaat`, `wfBelastingTarief`).
- New table header (`Component | Bedrag | % van Bruto | Impact`) — the previous `% van Totaal` column was not meaningful (it referenced final net worth, not a real share).
- Short intro copy explaining what the waterfall actually shows.

### `css/pages/waterfall.css`
- Styles for the per-row label + description layout and the new summary row.

## Verification

- `npm run build` succeeds.
- Numerically verified via the calculator for multiple configurations that `startValue + Σ(flow) === Eindvermogen` exactly, including edge cases where the loan does not fully amortise over the investment horizon (`leningLooptijd > looptijd`, `aflossingsvrij`), which previously broke the arithmetic.
- Existing behaviours (state change listeners, period selector, compare-modal, trends panel, export) still wire up to the same public API (`getWaterfallData`, `exportWaterfallData`), so the export module and other tabs keep working unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

