### PR TITLE
Waterfall follow-up: loan context, mobile layout, consistent equity naming

### DIFF
--- a/css/pages/waterfall.css
+++ b/css/pages/waterfall.css
@@ -337,11 +337,11 @@ input:checked + .toggle-slider:before {
 }
 
 .cashflow-table .component-description {
-    margin-top: 2px;
+    margin-top: 4px;
     font-size: var(--font-xs);
     color: #6c757d;
     font-weight: 400;
-    line-height: 1.3;
+    line-height: 1.4;
     white-space: normal;
     max-width: 360px;
 }
@@ -357,6 +357,79 @@ input:checked + .toggle-slider:before {
 
 .cashflow-table tr.summary-row:hover {
     background: #f1f3f5;
+}
+
+/* Loan context panel - explains how the loan flows through the period
+   since it is deliberately not shown as a bar in the waterfall itself. */
+.loan-context {
+    background: white;
+    border-radius: 12px;
+    padding: 25px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+    border-left: 4px solid #1e3c72;
+}
+
+.loan-context[hidden] {
+    display: none;
+}
+
+.loan-context-title {
+    color: #1e3c72;
+    margin: 0 0 10px 0;
+    font-size: 18px;
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+}
+
+.loan-context-intro {
+    color: #495057;
+    margin: 0 0 18px 0;
+    font-size: var(--font-sm);
+    line-height: 1.5;
+}
+
+.loan-context-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: var(--spacing-lg);
+}
+
+.loan-context-item {
+    background: #f8f9fa;
+    padding: var(--spacing-lg);
+    border-radius: 8px;
+    border: 1px solid #e9ecef;
+}
+
+.loan-context-label {
+    font-size: var(--font-xs);
+    color: #6c757d;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    margin-bottom: 6px;
+}
+
+.loan-context-value {
+    font-size: 20px;
+    font-weight: 700;
+    color: #1e3c72;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 6px;
+}
+
+.loan-context-value--negative {
+    color: #dc3545;
+}
+
+.loan-context-note {
+    font-size: 11px;
+    font-weight: 500;
+    color: #6c757d;
+    text-transform: none;
+    letter-spacing: 0;
 }
 
 /* Impact Bar */
@@ -755,25 +828,88 @@ input:checked + .toggle-slider:before {
         min-width: fit-content;
     }
     
-    .cashflow-table {
-        min-width: 600px;
+    /* On phones the 4-column component table simply does not fit, so we
+       convert each row into a stacked card. The cell labels we set via
+       data-label become inline labels so values stay readable without
+       any horizontal scrolling. */
+    .table-wrapper {
+        overflow-x: visible;
+        border: none;
+        border-radius: 0;
     }
-    
+
+    .cashflow-table,
+    .cashflow-table thead,
+    .cashflow-table tbody,
     .cashflow-table th,
+    .cashflow-table td,
+    .cashflow-table tr {
+        display: block;
+        width: 100%;
+    }
+
+    .cashflow-table {
+        min-width: 0;
+    }
+
+    .cashflow-table thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+    }
+
+    .cashflow-table tbody tr {
+        background: white;
+        border: 1px solid #e9ecef;
+        border-radius: 10px;
+        padding: 12px 14px;
+        margin-bottom: 10px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+    }
+
+    .cashflow-table tbody tr:hover {
+        background: white;
+    }
+
+    .cashflow-table tbody tr.summary-row {
+        background: #f1f6ff;
+        border-color: #cfe2ff;
+    }
+
     .cashflow-table td {
-        padding: var(--spacing-md) 8px;
-        font-size: var(--font-xs);
+        padding: 4px 0;
+        border-bottom: none;
+        text-align: left;
+        font-size: var(--font-sm);
     }
-    
-    .cashflow-table th:first-child,
+
     .cashflow-table td:first-child {
-        min-width: 120px;
-        font-size: 13px;
+        padding-bottom: 8px;
+        margin-bottom: 6px;
+        border-bottom: 1px solid #e9ecef;
+        min-width: 0;
+        font-size: var(--font-base);
     }
-    
+
+    .cashflow-table td[data-label]::before {
+        content: attr(data-label) ":";
+        display: inline-block;
+        min-width: 110px;
+        color: #6c757d;
+        font-weight: 500;
+        margin-right: 8px;
+    }
+
+    .cashflow-table .component-description {
+        max-width: 100%;
+    }
+
     .impact-bar {
-        width: 60px;
-        height: 16px;
+        width: 100%;
+        max-width: 180px;
+        height: 14px;
     }
     
     .trends-grid {
@@ -892,16 +1028,21 @@ input:checked + .toggle-slider:before {
         font-size: var(--font-xs);
     }
     
+    /* Keep the stacked-card layout from the 768px breakpoint at extra
+       small sizes - any min-width here would reintroduce horizontal
+       scrolling. */
     .cashflow-table {
-        min-width: 500px;
+        min-width: 0;
     }
-    
-    .cashflow-table th,
+
     .cashflow-table td {
-        padding: var(--spacing-sm) 6px;
-        font-size: 11px;
+        font-size: var(--font-sm);
     }
-    
+
+    .cashflow-table td[data-label]::before {
+        min-width: 96px;
+    }
+
     .ratios-grid {
         grid-template-columns: 1fr;
     }

--- a/js/core/calculator.js
+++ b/js/core/calculator.js
@@ -403,25 +403,33 @@ export class Calculator {
 
         const finalValue = this.data.totaalVermogen[this.data.totaalVermogen.length - 1];
 
+        // Loan balances at the boundaries of the selected period. We read
+        // them straight from the yearly snapshots the calculator already
+        // stores so the numbers line up exactly with the rest of the UI.
+        const leningStart = this.data.lening.length > 0 ? this.data.lening[0] : inputs.lening;
+        const leningEnd = this.data.lening.length > 0
+            ? this.data.lening[this.data.lening.length - 1]
+            : inputs.lening;
+
         // The waterfall visualises the change of the investor's OWN equity
         // over the period. Lening (loan proceeds) and aflossingen (principal
-        // repayments) cancel out on net worth - they only shift value between
+        // repayments) cancel out on equity - they only shift value between
         // portfolio/cash and the outstanding debt. We therefore keep them in
-        // `totals` for informational use but deliberately leave them OUT of
-        // the flow so the bars add up to Eindvermogen.
+        // `totals` / `loanInfo` for context but deliberately leave them OUT
+        // of the flow so the bars add up exactly to the change in equity.
         return {
             data: [
                 {
-                    label: 'Start Kapitaal',
+                    label: 'Eigen Vermogen (start)',
                     value: inputs.startKapitaal,
                     type: 'start',
-                    description: 'Eigen inbreng aan het begin van de periode.'
+                    description: 'Eigen vermogen aan het begin: je eigen inbreng. Een eventuele lening telt hier niet mee (die is tegelijk bezit én schuld).'
                 },
                 {
                     label: 'Bruto Rendement',
                     value: totals.bruttoOpbrengst,
                     type: 'positive',
-                    description: 'Rendement op de totale portefeuille (incl. eventuele lening), vóór belasting en kosten.'
+                    description: 'Rendement op de totale portefeuille (eigen kapitaal + lening samen), vóór belasting en kosten. Leverage laat dit bedrag groter uitvallen dan rendement op alleen eigen geld.'
                 },
                 {
                     label: 'Belasting',
@@ -433,7 +441,7 @@ export class Calculator {
                     label: 'Rentelasten',
                     value: -totals.rente,
                     type: 'negative',
-                    description: 'Rente betaald op de lening gedurende de periode.'
+                    description: 'Rente die over de periode op de lening is betaald.'
                 },
                 {
                     label: 'Vaste Kosten',
@@ -442,18 +450,20 @@ export class Calculator {
                     description: 'Doorlopende vaste kosten gedurende de periode.'
                 },
                 {
-                    label: 'Eindvermogen',
+                    label: 'Eigen Vermogen (eind)',
                     value: finalValue,
                     type: 'total',
-                    description: 'Eigen vermogen aan het einde: portefeuille + cash − restschuld lening.'
+                    description: 'Eigen vermogen aan het einde: portefeuille + cash − restschuld van de lening.'
                 }
             ],
             totals,
             finalValue,
             startValue: inputs.startKapitaal,
             loanInfo: {
-                lening: inputs.lening,
-                aflossingTotaal: totals.aflossing
+                leningStart,
+                leningEnd,
+                aflossingTotaal: totals.aflossing,
+                renteTotaal: totals.rente
             }
         };
     }
@@ -483,10 +493,17 @@ export class Calculator {
 
         const endValue = this.data.totaalVermogen[year] || startValue;
 
+        const leningStart = this.data.lening[year - 1] !== undefined
+            ? this.data.lening[year - 1]
+            : inputs.lening;
+        const leningEnd = this.data.lening[year] !== undefined
+            ? this.data.lening[year]
+            : leningStart;
+
         return {
             data: [
                 {
-                    label: 'Beginvermogen',
+                    label: 'Eigen Vermogen (begin jaar)',
                     value: startValue,
                     type: 'start',
                     description: 'Eigen vermogen aan het begin van dit jaar (portefeuille + cash − restschuld lening).'
@@ -495,7 +512,7 @@ export class Calculator {
                     label: 'Bruto Rendement',
                     value: yearTotals.bruttoOpbrengst,
                     type: 'positive',
-                    description: 'Rendement op de portefeuille in dit jaar, vóór belasting en kosten.'
+                    description: 'Rendement op de portefeuille in dit jaar (eigen kapitaal + lening samen), vóór belasting en kosten.'
                 },
                 {
                     label: 'Belasting',
@@ -516,7 +533,7 @@ export class Calculator {
                     description: 'Doorlopende vaste kosten in dit jaar.'
                 },
                 {
-                    label: 'Eindvermogen',
+                    label: 'Eigen Vermogen (eind jaar)',
                     value: endValue,
                     type: 'total',
                     description: 'Eigen vermogen aan het einde van dit jaar (portefeuille + cash − restschuld lening).'
@@ -526,7 +543,10 @@ export class Calculator {
             finalValue: endValue,
             startValue,
             loanInfo: {
-                aflossingTotaal: yearTotals.aflossing
+                leningStart,
+                leningEnd,
+                aflossingTotaal: yearTotals.aflossing,
+                renteTotaal: yearTotals.rente
             }
         };
     }

--- a/js/features/waterfall.js
+++ b/js/features/waterfall.js
@@ -133,6 +133,7 @@ export class WaterfallFeature {
         if (waterfallData && waterfallData.totals) {
             this.updateSummaryCards(waterfallData.totals);
             this.updateWaterfallChart(waterfallData);
+            this.updateLoanContext(waterfallData);
             this.updateTable(waterfallData);
             this.generateInsights(waterfallData);
         }
@@ -171,12 +172,12 @@ export class WaterfallFeature {
 
         const mockData = {
             data: [
-                { label: 'Start Kapitaal', value: 100000, type: 'start', description: 'Eigen inbreng aan het begin van de periode.' },
+                { label: 'Eigen Vermogen (start)', value: 100000, type: 'start', description: 'Eigen vermogen aan het begin: je eigen inbreng.' },
                 { label: 'Bruto Rendement', value: 15000, type: 'positive', description: 'Rendement op de totale portefeuille, vóór belasting en kosten.' },
                 { label: 'Belasting', value: -3750, type: 'negative', description: 'Belasting over het rendement.' },
                 { label: 'Rentelasten', value: -2500, type: 'negative', description: 'Rente betaald op de lening.' },
                 { label: 'Vaste Kosten', value: -1200, type: 'negative', description: 'Doorlopende vaste kosten.' },
-                { label: 'Eindvermogen', value: 107550, type: 'total', description: 'Eigen vermogen aan het einde van de periode.' }
+                { label: 'Eigen Vermogen (eind)', value: 107550, type: 'total', description: 'Eigen vermogen aan het einde van de periode.' }
             ],
             totals: {
                 bruttoOpbrengst: 15000,
@@ -187,7 +188,12 @@ export class WaterfallFeature {
             },
             startValue: 100000,
             finalValue: 107550,
-            loanInfo: { lening: 50000, aflossingTotaal: 10000 },
+            loanInfo: {
+                leningStart: 50000,
+                leningEnd: 40000,
+                aflossingTotaal: 10000,
+                renteTotaal: 2500
+            },
             period: period
         };
 
@@ -369,6 +375,14 @@ export class WaterfallFeature {
         // costs and what is left as net equity growth.
         const referenceValue = bruto > 0 ? bruto : 1;
 
+        // Labels come from localized rows so we keep them in one place
+        // instead of sprinkling strings through the template.
+        const colLabels = {
+            bedrag: 'Bedrag',
+            shareBruto: '% van Bruto',
+            impact: 'Impact'
+        };
+
         let html = '';
 
         waterfallData.data.forEach(item => {
@@ -388,18 +402,23 @@ export class WaterfallFeature {
             const description = item.description
                 ? `<div class="component-description">${item.description}</div>`
                 : '';
+            const labelBlock = `
+                <div class="component-label">${item.label}</div>
+                ${description}
+            `;
+
+            const valueClass = item.value < 0 ? 'negative' : item.value > 0 ? 'positive' : '';
+            const amountText = this.formatCurrency(item.value);
+            const shareText = bruto > 0 ? percentageOfBruto.toFixed(1) + '%' : '—';
 
             html += `
                 <tr>
-                    <td>
-                        <div class="component-label">${item.label}</div>
-                        ${description}
+                    <td>${labelBlock}</td>
+                    <td class="${valueClass}" data-label="${colLabels.bedrag}">
+                        ${amountText}
                     </td>
-                    <td class="${item.value < 0 ? 'negative' : item.value > 0 ? 'positive' : ''}">
-                        ${this.formatCurrency(item.value)}
-                    </td>
-                    <td>${bruto > 0 ? percentageOfBruto.toFixed(1) + '%' : '—'}</td>
-                    <td>${impactBar}</td>
+                    <td data-label="${colLabels.shareBruto}">${shareText}</td>
+                    <td data-label="${colLabels.impact}">${impactBar}</td>
                 </tr>
             `;
         });
@@ -416,16 +435,75 @@ export class WaterfallFeature {
                 <tr class="summary-row">
                     <td>
                         <div class="component-label">Δ Eigen Vermogen</div>
-                        <div class="component-description">Eindvermogen − Beginvermogen (moet gelijk zijn aan bruto − belasting − rente − kosten).</div>
+                        <div class="component-description">Eigen Vermogen (eind) − Eigen Vermogen (start). Per definitie gelijk aan Bruto Rendement − Belasting − Rentelasten − Vaste Kosten.</div>
                     </td>
-                    <td class="${deltaClass}">${this.formatCurrency(delta)}</td>
-                    <td>—</td>
-                    <td></td>
+                    <td class="${deltaClass}" data-label="${colLabels.bedrag}">${this.formatCurrency(delta)}</td>
+                    <td data-label="${colLabels.shareBruto}">—</td>
+                    <td data-label="${colLabels.impact}"></td>
                 </tr>
             `;
         }
 
         tbody.innerHTML = html;
+    }
+
+    /**
+     * Render a small panel that explains how the loan moves through the
+     * period. The waterfall chart intentionally leaves lening and aflossing
+     * out of the flow (they do not change equity), so users need a separate
+     * context view to see why the lening is not a bar on the chart.
+     */
+    updateLoanContext(waterfallData) {
+        const container = document.getElementById('waterfallLoanContext');
+        if (!container) return;
+
+        const info = waterfallData.loanInfo || {};
+        const leningStart = Number(info.leningStart || 0);
+        const leningEnd = Number(info.leningEnd || 0);
+        const aflossing = Number(info.aflossingTotaal || 0);
+        const rente = Number(info.renteTotaal || 0);
+
+        // When the scenario has no leverage at all, hide the panel instead
+        // of showing four zero rows which adds clutter without information.
+        if (leningStart <= 0 && leningEnd <= 0 && aflossing <= 0 && rente <= 0) {
+            container.hidden = true;
+            container.innerHTML = '';
+            return;
+        }
+
+        container.hidden = false;
+        container.innerHTML = `
+            <h4 class="loan-context-title">🏦 Lening in deze periode</h4>
+            <p class="loan-context-intro">
+                De lening staat niet als losse balk in de waterfall: geleend geld verhoogt je
+                bezit én je schuld met hetzelfde bedrag, en heeft dus geen direct effect op je
+                eigen vermogen. Een eventuele aflossing verschuift alleen geld van je cashpositie
+                naar de schuld. Wat wél invloed heeft op het eigen vermogen is de rente — die is
+                al opgenomen als &quot;Rentelasten&quot; in de waterfall. Hieronder zie je hoe de
+                lening zich in deze periode ontwikkelt.
+            </p>
+            <div class="loan-context-grid">
+                <div class="loan-context-item">
+                    <div class="loan-context-label">Openstaande lening begin</div>
+                    <div class="loan-context-value">${this.formatCurrency(leningStart)}</div>
+                </div>
+                <div class="loan-context-item">
+                    <div class="loan-context-label">Aflossingen in periode</div>
+                    <div class="loan-context-value">${this.formatCurrency(aflossing)}</div>
+                </div>
+                <div class="loan-context-item">
+                    <div class="loan-context-label">Openstaande lening eind</div>
+                    <div class="loan-context-value">${this.formatCurrency(leningEnd)}</div>
+                </div>
+                <div class="loan-context-item">
+                    <div class="loan-context-label">Rente betaald</div>
+                    <div class="loan-context-value loan-context-value--negative">
+                        ${this.formatCurrency(rente)}
+                        <span class="loan-context-note">(in waterfall opgenomen)</span>
+                    </div>
+                </div>
+            </div>
+        `;
     }
 
     generateInsights(waterfallData) {

--- a/public/templates/waterfall.html
+++ b/public/templates/waterfall.html
@@ -1,8 +1,12 @@
 <section id="waterfall" class="tab-pane" role="tabpanel">
     <h2>💧 Cashflow Waterfall Analyse</h2>
     <p class="tab-description">
-        Van <strong>Start Kapitaal</strong> via <strong>Bruto Rendement</strong>, minus belasting, rente en vaste kosten,
-        naar <strong>Eindvermogen</strong>. De componenten tellen exact op tot de verandering in eigen vermogen over de periode.
+        Van <strong>Eigen Vermogen (start)</strong> via <strong>Bruto Rendement</strong>, minus belasting,
+        rente en vaste kosten, naar <strong>Eigen Vermogen (eind)</strong>. Een eventuele lening zit niet
+        als losse balk in de waterfall omdat die tegelijk bezit én schuld is; de invloed van de lening
+        loopt via <em>Bruto Rendement</em> (rendement ook over het geleende bedrag) en
+        <em>Rentelasten</em>. De ontwikkeling van de lening zelf zie je in het blok &quot;Lening in deze
+        periode&quot; onder de grafiek.
     </p>
 
     <!-- Controls Section -->
@@ -71,6 +75,11 @@
         <canvas id="waterfallChart"></canvas>
     </div>
 
+    <!-- Loan Context Panel (hidden when there is no leverage) -->
+    <div id="waterfallLoanContext" class="loan-context mt-4" hidden>
+        <!-- Dynamically populated -->
+    </div>
+
     <!-- Analysis Section -->
     <div class="waterfall-analysis mt-4">
         <h3>📊 Cashflow Breakdown</h3>
@@ -120,8 +129,4 @@
         </div>
     </div>
 
-    <!-- Mobile Hint -->
-    <div class="mobile-table-hint mt-2">
-        💡 Tip: Swipe de tabel horizontaal om alle kolommen te zien
-    </div>
 </section>

--- a/templates/waterfall.html
+++ b/templates/waterfall.html
@@ -1,8 +1,12 @@
 <section id="waterfall" class="tab-pane" role="tabpanel">
     <h2>💧 Cashflow Waterfall Analyse</h2>
     <p class="tab-description">
-        Van <strong>Start Kapitaal</strong> via <strong>Bruto Rendement</strong>, minus belasting, rente en vaste kosten,
-        naar <strong>Eindvermogen</strong>. De componenten tellen exact op tot de verandering in eigen vermogen over de periode.
+        Van <strong>Eigen Vermogen (start)</strong> via <strong>Bruto Rendement</strong>, minus belasting,
+        rente en vaste kosten, naar <strong>Eigen Vermogen (eind)</strong>. Een eventuele lening zit niet
+        als losse balk in de waterfall omdat die tegelijk bezit én schuld is; de invloed van de lening
+        loopt via <em>Bruto Rendement</em> (rendement ook over het geleende bedrag) en
+        <em>Rentelasten</em>. De ontwikkeling van de lening zelf zie je in het blok &quot;Lening in deze
+        periode&quot; onder de grafiek.
     </p>
 
     <!-- Controls Section -->
@@ -71,6 +75,11 @@
         <canvas id="waterfallChart"></canvas>
     </div>
 
+    <!-- Loan Context Panel (hidden when there is no leverage) -->
+    <div id="waterfallLoanContext" class="loan-context mt-4" hidden>
+        <!-- Dynamically populated -->
+    </div>
+
     <!-- Analysis Section -->
     <div class="waterfall-analysis mt-4">
         <h3>📊 Cashflow Breakdown</h3>
@@ -120,8 +129,4 @@
         </div>
     </div>
 
-    <!-- Mobile Hint -->
-    <div class="mobile-table-hint mt-2">
-        💡 Tip: Swipe de tabel horizontaal om alle kolommen te zien
-    </div>
 </section>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three follow-up issues on the cashflow waterfall:

## 1. Components table did not fit on mobile

The description column made each row wider than a phone screen, which forced horizontal scrolling.

Below 768px the table now converts to a **stacked card layout** — each row becomes its own card with the component label and description on top, and every numeric cell is labelled inline via `data-label` pseudo-elements. The `min-width` rules that kept forcing horizontal scrolling (at both the 768px and 480px breakpoints) are gone, and the *"swipe the table"* mobile hint is dropped because there is nothing left to swipe.

## 2. How does the lening factor into the waterfall?

The waterfall intentionally leaves `Lening` and `Aflossingen` out of the flow because they don't change eigen vermogen (they move value between bezit and schuld). That is correct, but it left users wondering where the lening actually *went*.

- `js/core/calculator.js`: `loanInfo` now returns `leningStart`, `leningEnd`, `aflossingTotaal`, `renteTotaal` for every period (yearly snapshots for per-year views, total-period boundaries for *Totaal*).
- A new **"Lening in deze periode"** panel is rendered under the chart. It shows:
  - Openstaande lening begin
  - Aflossingen in periode
  - Openstaande lening eind
  - Rente betaald (marked as already part of the waterfall as *Rentelasten*)
- The panel includes a short explanation of *why* the lening is not a bar: geleend geld verhoogt je bezit én je schuld met hetzelfde bedrag, dus direct effect op eigen vermogen is nul. De echte invloed zit in **Bruto Rendement** (leverage op rendement) en **Rentelasten**.
- The panel hides itself automatically when the scenario has no leverage.

## 3. `Eindvermogen` vs `Eigen Vermogen` was confusing

The chart bar was labelled `Eindvermogen` and the components table talked about `Eigen Vermogen`, which read as two different concepts.

All labels now use **Eigen Vermogen** as the single concept, qualified by time:

- **Totaal**: `Eigen Vermogen (start)` → … → `Eigen Vermogen (eind)`
- **Jaarlijks**: `Eigen Vermogen (begin jaar)` → … → `Eigen Vermogen (eind jaar)`

The tab description was rewritten in the same vocabulary, and the summary row in the components table is labelled **Δ Eigen Vermogen**, with an explanation that this is by construction equal to `Bruto Rendement − Belasting − Rentelasten − Vaste Kosten`.

## Verification

- `npm run build` passes.
- Calculator check: `Start + Σ(flow) === Eigen Vermogen (eind)` exactly for both the full period and individual years, including the previously-problematic case where `leningLooptijd > looptijd` so the loan is not fully amortised inside the investment horizon.
- `loanInfo` is populated correctly on both paths: for the total view it reflects the original lening and total aflossing over the whole horizon; for a year view it reflects the lening balance at the year boundaries and the aflossing/rente that actually happened in that single year.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

