### PR TITLE
Simplify waterfall copy: drop verbose descriptions and intros

### DIFF
--- a/css/pages/waterfall.css
+++ b/css/pages/waterfall.css
@@ -336,31 +336,9 @@ input:checked + .toggle-slider:before {
     color: #212529;
 }
 
-.cashflow-table .component-description {
-    margin-top: 4px;
-    font-size: var(--font-xs);
-    color: #6c757d;
-    font-weight: 400;
-    line-height: 1.4;
-    white-space: normal;
-    max-width: 360px;
-}
-
-.cashflow-table tr.summary-row {
-    background: #f8f9fa;
-    border-top: 2px solid #dee2e6;
-}
-
-.cashflow-table tr.summary-row td {
-    font-weight: 600;
-}
-
-.cashflow-table tr.summary-row:hover {
-    background: #f1f3f5;
-}
-
-/* Loan context panel - explains how the loan flows through the period
-   since it is deliberately not shown as a bar in the waterfall itself. */
+/* Loan context panel - surfaces the loan's development (begin/end
+   balance, repayments, interest) alongside the equity waterfall, since
+   lening and aflossingen are intentionally not shown as chart bars. */
 .loan-context {
     background: white;
     border-radius: 12px;
@@ -375,18 +353,11 @@ input:checked + .toggle-slider:before {
 
 .loan-context-title {
     color: #1e3c72;
-    margin: 0 0 10px 0;
+    margin: 0 0 15px 0;
     font-size: 18px;
     display: flex;
     align-items: center;
     gap: var(--spacing-sm);
-}
-
-.loan-context-intro {
-    color: #495057;
-    margin: 0 0 18px 0;
-    font-size: var(--font-sm);
-    line-height: 1.5;
 }
 
 .loan-context-grid {
@@ -414,22 +385,10 @@ input:checked + .toggle-slider:before {
     font-size: 20px;
     font-weight: 700;
     color: #1e3c72;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 6px;
 }
 
 .loan-context-value--negative {
     color: #dc3545;
-}
-
-.loan-context-note {
-    font-size: 11px;
-    font-weight: 500;
-    color: #6c757d;
-    text-transform: none;
-    letter-spacing: 0;
 }
 
 /* Impact Bar */
@@ -873,11 +832,6 @@ input:checked + .toggle-slider:before {
         background: white;
     }
 
-    .cashflow-table tbody tr.summary-row {
-        background: #f1f6ff;
-        border-color: #cfe2ff;
-    }
-
     .cashflow-table td {
         padding: 4px 0;
         border-bottom: none;
@@ -900,10 +854,6 @@ input:checked + .toggle-slider:before {
         color: #6c757d;
         font-weight: 500;
         margin-right: 8px;
-    }
-
-    .cashflow-table .component-description {
-        max-width: 100%;
     }
 
     .impact-bar {

--- a/js/core/calculator.js
+++ b/js/core/calculator.js
@@ -419,42 +419,12 @@ export class Calculator {
         // of the flow so the bars add up exactly to the change in equity.
         return {
             data: [
-                {
-                    label: 'Eigen Vermogen (start)',
-                    value: inputs.startKapitaal,
-                    type: 'start',
-                    description: 'Eigen vermogen aan het begin: je eigen inbreng. Een eventuele lening telt hier niet mee (die is tegelijk bezit én schuld).'
-                },
-                {
-                    label: 'Bruto Rendement',
-                    value: totals.bruttoOpbrengst,
-                    type: 'positive',
-                    description: 'Rendement op de totale portefeuille (eigen kapitaal + lening samen), vóór belasting en kosten. Leverage laat dit bedrag groter uitvallen dan rendement op alleen eigen geld.'
-                },
-                {
-                    label: 'Belasting',
-                    value: -totals.belasting,
-                    type: 'negative',
-                    description: 'Belasting over het rendement (afhankelijk van het gekozen belastingregime).'
-                },
-                {
-                    label: 'Rentelasten',
-                    value: -totals.rente,
-                    type: 'negative',
-                    description: 'Rente die over de periode op de lening is betaald.'
-                },
-                {
-                    label: 'Vaste Kosten',
-                    value: -totals.kosten,
-                    type: 'negative',
-                    description: 'Doorlopende vaste kosten gedurende de periode.'
-                },
-                {
-                    label: 'Eigen Vermogen (eind)',
-                    value: finalValue,
-                    type: 'total',
-                    description: 'Eigen vermogen aan het einde: portefeuille + cash − restschuld van de lening.'
-                }
+                { label: 'Eigen Vermogen (start)', value: inputs.startKapitaal, type: 'start' },
+                { label: 'Bruto Rendement', value: totals.bruttoOpbrengst, type: 'positive' },
+                { label: 'Belasting', value: -totals.belasting, type: 'negative' },
+                { label: 'Rentelasten', value: -totals.rente, type: 'negative' },
+                { label: 'Vaste Kosten', value: -totals.kosten, type: 'negative' },
+                { label: 'Eigen Vermogen (eind)', value: finalValue, type: 'total' }
             ],
             totals,
             finalValue,
@@ -502,42 +472,12 @@ export class Calculator {
 
         return {
             data: [
-                {
-                    label: 'Eigen Vermogen (begin jaar)',
-                    value: startValue,
-                    type: 'start',
-                    description: 'Eigen vermogen aan het begin van dit jaar (portefeuille + cash − restschuld lening).'
-                },
-                {
-                    label: 'Bruto Rendement',
-                    value: yearTotals.bruttoOpbrengst,
-                    type: 'positive',
-                    description: 'Rendement op de portefeuille in dit jaar (eigen kapitaal + lening samen), vóór belasting en kosten.'
-                },
-                {
-                    label: 'Belasting',
-                    value: -yearTotals.belasting,
-                    type: 'negative',
-                    description: 'Belasting over het rendement in dit jaar.'
-                },
-                {
-                    label: 'Rentelasten',
-                    value: -yearTotals.rente,
-                    type: 'negative',
-                    description: 'Rente betaald op de lening in dit jaar.'
-                },
-                {
-                    label: 'Vaste Kosten',
-                    value: -yearTotals.kosten,
-                    type: 'negative',
-                    description: 'Doorlopende vaste kosten in dit jaar.'
-                },
-                {
-                    label: 'Eigen Vermogen (eind jaar)',
-                    value: endValue,
-                    type: 'total',
-                    description: 'Eigen vermogen aan het einde van dit jaar (portefeuille + cash − restschuld lening).'
-                }
+                { label: 'Eigen Vermogen (begin jaar)', value: startValue, type: 'start' },
+                { label: 'Bruto Rendement', value: yearTotals.bruttoOpbrengst, type: 'positive' },
+                { label: 'Belasting', value: -yearTotals.belasting, type: 'negative' },
+                { label: 'Rentelasten', value: -yearTotals.rente, type: 'negative' },
+                { label: 'Vaste Kosten', value: -yearTotals.kosten, type: 'negative' },
+                { label: 'Eigen Vermogen (eind jaar)', value: endValue, type: 'total' }
             ],
             totals: yearTotals,
             finalValue: endValue,

--- a/js/features/waterfall.js
+++ b/js/features/waterfall.js
@@ -172,12 +172,12 @@ export class WaterfallFeature {
 
         const mockData = {
             data: [
-                { label: 'Eigen Vermogen (start)', value: 100000, type: 'start', description: 'Eigen vermogen aan het begin: je eigen inbreng.' },
-                { label: 'Bruto Rendement', value: 15000, type: 'positive', description: 'Rendement op de totale portefeuille, vóór belasting en kosten.' },
-                { label: 'Belasting', value: -3750, type: 'negative', description: 'Belasting over het rendement.' },
-                { label: 'Rentelasten', value: -2500, type: 'negative', description: 'Rente betaald op de lening.' },
-                { label: 'Vaste Kosten', value: -1200, type: 'negative', description: 'Doorlopende vaste kosten.' },
-                { label: 'Eigen Vermogen (eind)', value: 107550, type: 'total', description: 'Eigen vermogen aan het einde van de periode.' }
+                { label: 'Eigen Vermogen (start)', value: 100000, type: 'start' },
+                { label: 'Bruto Rendement', value: 15000, type: 'positive' },
+                { label: 'Belasting', value: -3750, type: 'negative' },
+                { label: 'Rentelasten', value: -2500, type: 'negative' },
+                { label: 'Vaste Kosten', value: -1200, type: 'negative' },
+                { label: 'Eigen Vermogen (eind)', value: 107550, type: 'total' }
             ],
             totals: {
                 bruttoOpbrengst: 15000,
@@ -225,11 +225,10 @@ export class WaterfallFeature {
         this.updateElement('wfKostenDetail', `Rente: ${this.formatCurrency(rente)} | Vaste kosten: ${this.formatCurrency(kosten)}`);
 
         this.updateElement('wfNettoResultaat', this.formatCurrency(nettoResultaat));
-        this.updateElement('wfNettoResultaatDetail',
-            `${efficientie.toFixed(1)}% van bruto · verandert het eigen vermogen`);
+        this.updateElement('wfNettoResultaatDetail', `${efficientie.toFixed(1)}% van bruto rendement`);
 
         this.updateElement('wfBelastingTarief', `${belastingTarief.toFixed(1)}%`);
-        this.updateElement('wfBelastingDetail', `Belasting ${this.formatCurrency(belasting)} op bruto rendement`);
+        this.updateElement('wfBelastingDetail', `Op bruto rendement`);
     }
 
     updateWaterfallChart(waterfallData) {
@@ -322,10 +321,7 @@ export class WaterfallFeature {
                         },
                         tooltip: {
                             callbacks: {
-                                title: (items) => {
-                                    if (!items || !items.length) return '';
-                                    return items[0].label || '';
-                                },
+                                title: (items) => (items && items.length ? items[0].label || '' : ''),
                                 label: (context) => {
                                     const current = this.currentWaterfallData;
                                     const item = current && current.data
@@ -339,13 +335,6 @@ export class WaterfallFeature {
 
                                     const sign = item.value >= 0 ? '+' : '−';
                                     return `${sign} ${this.formatCurrency(Math.abs(item.value))}`;
-                                },
-                                afterLabel: (context) => {
-                                    const current = this.currentWaterfallData;
-                                    const item = current && current.data
-                                        ? current.data[context.dataIndex]
-                                        : null;
-                                    return item && item.description ? item.description : '';
                                 }
                             }
                         }
@@ -369,19 +358,11 @@ export class WaterfallFeature {
 
         const totals = waterfallData.totals || {};
         const bruto = Math.max(totals.bruttoOpbrengst || 0, 0);
-
-        // Use bruto rendement as the reference for share-of calculations. It
-        // represents the income that is being divided over tax, interest,
-        // costs and what is left as net equity growth.
         const referenceValue = bruto > 0 ? bruto : 1;
 
-        // Labels come from localized rows so we keep them in one place
-        // instead of sprinkling strings through the template.
-        const colLabels = {
-            bedrag: 'Bedrag',
-            shareBruto: '% van Bruto',
-            impact: 'Impact'
-        };
+        // data-label values double as the column name in the mobile
+        // stacked-card layout (see waterfall.css).
+        const colLabels = { bedrag: 'Bedrag', shareBruto: '% van Bruto', impact: 'Impact' };
 
         let html = '';
 
@@ -399,50 +380,18 @@ export class WaterfallFeature {
                 </div>
             `;
 
-            const description = item.description
-                ? `<div class="component-description">${item.description}</div>`
-                : '';
-            const labelBlock = `
-                <div class="component-label">${item.label}</div>
-                ${description}
-            `;
-
             const valueClass = item.value < 0 ? 'negative' : item.value > 0 ? 'positive' : '';
-            const amountText = this.formatCurrency(item.value);
             const shareText = bruto > 0 ? percentageOfBruto.toFixed(1) + '%' : '—';
 
             html += `
                 <tr>
-                    <td>${labelBlock}</td>
-                    <td class="${valueClass}" data-label="${colLabels.bedrag}">
-                        ${amountText}
-                    </td>
+                    <td><div class="component-label">${item.label}</div></td>
+                    <td class="${valueClass}" data-label="${colLabels.bedrag}">${this.formatCurrency(item.value)}</td>
                     <td data-label="${colLabels.shareBruto}">${shareText}</td>
                     <td data-label="${colLabels.impact}">${impactBar}</td>
                 </tr>
             `;
         });
-
-        // Append a summary row that makes the equity identity explicit so
-        // readers can verify that the components balance to the change in
-        // eigen vermogen for the selected period.
-        const startValue = waterfallData.startValue;
-        const finalValue = waterfallData.finalValue;
-        if (typeof startValue === 'number' && typeof finalValue === 'number') {
-            const delta = finalValue - startValue;
-            const deltaClass = delta >= 0 ? 'positive' : 'negative';
-            html += `
-                <tr class="summary-row">
-                    <td>
-                        <div class="component-label">Δ Eigen Vermogen</div>
-                        <div class="component-description">Eigen Vermogen (eind) − Eigen Vermogen (start). Per definitie gelijk aan Bruto Rendement − Belasting − Rentelasten − Vaste Kosten.</div>
-                    </td>
-                    <td class="${deltaClass}" data-label="${colLabels.bedrag}">${this.formatCurrency(delta)}</td>
-                    <td data-label="${colLabels.shareBruto}">—</td>
-                    <td data-label="${colLabels.impact}"></td>
-                </tr>
-            `;
-        }
 
         tbody.innerHTML = html;
     }
@@ -473,34 +422,23 @@ export class WaterfallFeature {
 
         container.hidden = false;
         container.innerHTML = `
-            <h4 class="loan-context-title">🏦 Lening in deze periode</h4>
-            <p class="loan-context-intro">
-                De lening staat niet als losse balk in de waterfall: geleend geld verhoogt je
-                bezit én je schuld met hetzelfde bedrag, en heeft dus geen direct effect op je
-                eigen vermogen. Een eventuele aflossing verschuift alleen geld van je cashpositie
-                naar de schuld. Wat wél invloed heeft op het eigen vermogen is de rente — die is
-                al opgenomen als &quot;Rentelasten&quot; in de waterfall. Hieronder zie je hoe de
-                lening zich in deze periode ontwikkelt.
-            </p>
+            <h4 class="loan-context-title">🏦 Lening</h4>
             <div class="loan-context-grid">
                 <div class="loan-context-item">
-                    <div class="loan-context-label">Openstaande lening begin</div>
+                    <div class="loan-context-label">Lening begin</div>
                     <div class="loan-context-value">${this.formatCurrency(leningStart)}</div>
                 </div>
                 <div class="loan-context-item">
-                    <div class="loan-context-label">Aflossingen in periode</div>
+                    <div class="loan-context-label">Aflossingen</div>
                     <div class="loan-context-value">${this.formatCurrency(aflossing)}</div>
                 </div>
                 <div class="loan-context-item">
-                    <div class="loan-context-label">Openstaande lening eind</div>
+                    <div class="loan-context-label">Lening eind</div>
                     <div class="loan-context-value">${this.formatCurrency(leningEnd)}</div>
                 </div>
                 <div class="loan-context-item">
                     <div class="loan-context-label">Rente betaald</div>
-                    <div class="loan-context-value loan-context-value--negative">
-                        ${this.formatCurrency(rente)}
-                        <span class="loan-context-note">(in waterfall opgenomen)</span>
-                    </div>
+                    <div class="loan-context-value loan-context-value--negative">${this.formatCurrency(rente)}</div>
                 </div>
             </div>
         `;

--- a/public/templates/waterfall.html
+++ b/public/templates/waterfall.html
@@ -1,12 +1,7 @@
 <section id="waterfall" class="tab-pane" role="tabpanel">
     <h2>💧 Cashflow Waterfall Analyse</h2>
     <p class="tab-description">
-        Van <strong>Eigen Vermogen (start)</strong> via <strong>Bruto Rendement</strong>, minus belasting,
-        rente en vaste kosten, naar <strong>Eigen Vermogen (eind)</strong>. Een eventuele lening zit niet
-        als losse balk in de waterfall omdat die tegelijk bezit én schuld is; de invloed van de lening
-        loopt via <em>Bruto Rendement</em> (rendement ook over het geleende bedrag) en
-        <em>Rentelasten</em>. De ontwikkeling van de lening zelf zie je in het blok &quot;Lening in deze
-        periode&quot; onder de grafiek.
+        Gedetailleerd overzicht van alle geldstromen per periode met visuele breakdown.
     </p>
 
     <!-- Controls Section -->
@@ -45,7 +40,7 @@
         <div class="summary-card negative">
             <div class="summary-icon">📉</div>
             <div class="summary-content">
-                <div class="summary-label">Kosten (rente + vaste kosten)</div>
+                <div class="summary-label">Kosten</div>
                 <div class="summary-value" id="wfKostenTotaal">€ 0</div>
                 <div class="summary-detail" id="wfKostenDetail">Rente: € 0 | Vaste kosten: € 0</div>
             </div>
@@ -56,7 +51,7 @@
             <div class="summary-content">
                 <div class="summary-label">Netto Resultaat</div>
                 <div class="summary-value" id="wfNettoResultaat">€ 0</div>
-                <div class="summary-detail" id="wfNettoResultaatDetail">0% van bruto · verandert het eigen vermogen</div>
+                <div class="summary-detail" id="wfNettoResultaatDetail">0% van bruto rendement</div>
             </div>
         </div>
 
@@ -65,7 +60,7 @@
             <div class="summary-content">
                 <div class="summary-label">Effectief Belastingtarief</div>
                 <div class="summary-value" id="wfBelastingTarief">0%</div>
-                <div class="summary-detail" id="wfBelastingDetail">Belasting € 0 op bruto rendement</div>
+                <div class="summary-detail" id="wfBelastingDetail">Op bruto rendement</div>
             </div>
         </div>
     </div>

--- a/templates/waterfall.html
+++ b/templates/waterfall.html
@@ -1,12 +1,7 @@
 <section id="waterfall" class="tab-pane" role="tabpanel">
     <h2>💧 Cashflow Waterfall Analyse</h2>
     <p class="tab-description">
-        Van <strong>Eigen Vermogen (start)</strong> via <strong>Bruto Rendement</strong>, minus belasting,
-        rente en vaste kosten, naar <strong>Eigen Vermogen (eind)</strong>. Een eventuele lening zit niet
-        als losse balk in de waterfall omdat die tegelijk bezit én schuld is; de invloed van de lening
-        loopt via <em>Bruto Rendement</em> (rendement ook over het geleende bedrag) en
-        <em>Rentelasten</em>. De ontwikkeling van de lening zelf zie je in het blok &quot;Lening in deze
-        periode&quot; onder de grafiek.
+        Gedetailleerd overzicht van alle geldstromen per periode met visuele breakdown.
     </p>
 
     <!-- Controls Section -->
@@ -45,7 +40,7 @@
         <div class="summary-card negative">
             <div class="summary-icon">📉</div>
             <div class="summary-content">
-                <div class="summary-label">Kosten (rente + vaste kosten)</div>
+                <div class="summary-label">Kosten</div>
                 <div class="summary-value" id="wfKostenTotaal">€ 0</div>
                 <div class="summary-detail" id="wfKostenDetail">Rente: € 0 | Vaste kosten: € 0</div>
             </div>
@@ -56,7 +51,7 @@
             <div class="summary-content">
                 <div class="summary-label">Netto Resultaat</div>
                 <div class="summary-value" id="wfNettoResultaat">€ 0</div>
-                <div class="summary-detail" id="wfNettoResultaatDetail">0% van bruto · verandert het eigen vermogen</div>
+                <div class="summary-detail" id="wfNettoResultaatDetail">0% van bruto rendement</div>
             </div>
         </div>
 
@@ -65,7 +60,7 @@
             <div class="summary-content">
                 <div class="summary-label">Effectief Belastingtarief</div>
                 <div class="summary-value" id="wfBelastingTarief">0%</div>
-                <div class="summary-detail" id="wfBelastingDetail">Belasting € 0 op bruto rendement</div>
+                <div class="summary-detail" id="wfBelastingDetail">Op bruto rendement</div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Keeps the useful pieces from the previous follow-up (mobile stacked-card layout, `loanInfo` on the calculator, consistent *Eigen Vermogen* naming) but trims the explanatory copy.

Removed:
- Per-component description text (chart tooltip, table row under label, mock data, calculator output).
- "Δ Eigen Vermogen" summary row in the components table with its formula explanation.
- The intro paragraph under "🏦 Lening" and the "(in waterfall opgenomen)" inline note.
- Unused CSS for `component-description`, `summary-row`, `loan-context-intro`, `loan-context-note`.

Shortened:
- Tab description back to the original one-liner.
- Summary card labels/details: *"Kosten"*, *"0% van bruto rendement"*, *"Op bruto rendement"*.
- Loan panel title: *"🏦 Lening"* with labels *"Lening begin / Aflossingen / Lening eind / Rente betaald"*.

Kept:
- Mobile stacked-card layout for the components table.
- `loanInfo` (leningStart / leningEnd / aflossingTotaal / renteTotaal) from the calculator and its rendering in the Lening panel.
- Consistent naming: `Eigen Vermogen (start|eind)` / `Eigen Vermogen (begin jaar|eind jaar)`.

Verified: `npm run build` passes and `Start + Σ(flow) === Eigen Vermogen (eind)` still holds.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

