### PR TITLE
Waterfall: scope mobile table CSS and harden tab switching

### DIFF
--- a/css/pages/waterfall.css
+++ b/css/pages/waterfall.css
@@ -787,31 +787,34 @@ input:checked + .toggle-slider:before {
         min-width: fit-content;
     }
     
-    /* On phones the 4-column component table simply does not fit, so we
-       convert each row into a stacked card. The cell labels we set via
-       data-label become inline labels so values stay readable without
-       any horizontal scrolling. */
-    .table-wrapper {
+    /* Stacked card layout for the waterfall components table. These
+       rules are intentionally scoped to `.waterfall-analysis` to beat
+       the generic `.cashflow-table` rules from components/tables.css
+       and responsive.css (which otherwise force a 500px min-width
+       and white-space: nowrap, causing horizontal scrolling). */
+    .waterfall-analysis .table-wrapper {
         overflow-x: visible;
         border: none;
         border-radius: 0;
+        margin-top: 10px;
+        background: transparent;
     }
 
-    .cashflow-table,
-    .cashflow-table thead,
-    .cashflow-table tbody,
-    .cashflow-table th,
-    .cashflow-table td,
-    .cashflow-table tr {
+    .waterfall-analysis .cashflow-table,
+    .waterfall-analysis .cashflow-table thead,
+    .waterfall-analysis .cashflow-table tbody,
+    .waterfall-analysis .cashflow-table th,
+    .waterfall-analysis .cashflow-table td,
+    .waterfall-analysis .cashflow-table tr {
         display: block;
         width: 100%;
-    }
-
-    .cashflow-table {
         min-width: 0;
+        white-space: normal;
+        position: static;
+        box-shadow: none;
     }
 
-    .cashflow-table thead {
+    .waterfall-analysis .cashflow-table thead {
         position: absolute;
         width: 1px;
         height: 1px;
@@ -819,7 +822,7 @@ input:checked + .toggle-slider:before {
         clip: rect(0 0 0 0);
     }
 
-    .cashflow-table tbody tr {
+    .waterfall-analysis .cashflow-table tbody tr {
         background: white;
         border: 1px solid #e9ecef;
         border-radius: 10px;
@@ -828,26 +831,25 @@ input:checked + .toggle-slider:before {
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
     }
 
-    .cashflow-table tbody tr:hover {
+    .waterfall-analysis .cashflow-table tbody tr:hover {
         background: white;
     }
 
-    .cashflow-table td {
+    .waterfall-analysis .cashflow-table td {
         padding: 4px 0;
         border-bottom: none;
         text-align: left;
         font-size: var(--font-sm);
     }
 
-    .cashflow-table td:first-child {
+    .waterfall-analysis .cashflow-table td:first-child {
         padding-bottom: 8px;
         margin-bottom: 6px;
         border-bottom: 1px solid #e9ecef;
-        min-width: 0;
         font-size: var(--font-base);
     }
 
-    .cashflow-table td[data-label]::before {
+    .waterfall-analysis .cashflow-table td[data-label]::before {
         content: attr(data-label) ":";
         display: inline-block;
         min-width: 110px;
@@ -856,7 +858,7 @@ input:checked + .toggle-slider:before {
         margin-right: 8px;
     }
 
-    .impact-bar {
+    .waterfall-analysis .impact-bar {
         width: 100%;
         max-width: 180px;
         height: 14px;
@@ -979,17 +981,17 @@ input:checked + .toggle-slider:before {
     }
     
     /* Keep the stacked-card layout from the 768px breakpoint at extra
-       small sizes - any min-width here would reintroduce horizontal
-       scrolling. */
-    .cashflow-table {
+       small sizes - scoped to .waterfall-analysis to stay specific
+       enough to override responsive.css. */
+    .waterfall-analysis .cashflow-table {
         min-width: 0;
     }
 
-    .cashflow-table td {
+    .waterfall-analysis .cashflow-table td {
         font-size: var(--font-sm);
     }
 
-    .cashflow-table td[data-label]::before {
+    .waterfall-analysis .cashflow-table td[data-label]::before {
         min-width: 96px;
     }
 

--- a/js/features/waterfall.js
+++ b/js/features/waterfall.js
@@ -87,9 +87,19 @@ export class WaterfallFeature {
             });
         }
 
-        document.querySelectorAll('.analysis-tab').forEach(tab => {
-            tab.addEventListener('click', (e) => this.switchAnalysisTab(e.currentTarget));
-        });
+        // Use delegation on the static `.analysis-tabs` container so we
+        // keep working even if the tab buttons are re-rendered. We also
+        // call .closest('.analysis-tab') so taps on a child element of
+        // the button (whitespace, icon, text node) still resolve to the
+        // right tab.
+        const analysisTabs = document.querySelector('.waterfall-analysis .analysis-tabs');
+        if (analysisTabs) {
+            analysisTabs.addEventListener('click', (e) => {
+                const tab = e.target.closest('.analysis-tab');
+                if (!tab || !analysisTabs.contains(tab)) return;
+                this.switchAnalysisTab(tab);
+            });
+        }
 
         this.handlersAttached = true;
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Two bugs reported on the waterfall tab:

**1. Cashflow Breakdown tabs don't switch.** Replaced the per-button click listeners with a single delegated listener on the `.analysis-tabs` container, resolving the target via `event.target.closest('.analysis-tab')`. Robust against re-renders and taps landing on a child node.

**2. Components table requires horizontal scrolling on mobile.** The generic `.cashflow-table` rules in `css/components/tables.css` and `css/responsive.css` (loaded last) kept re-applying `min-width: 500px` and `white-space: nowrap` at mobile breakpoints, with the same specificity as the waterfall stacked-card CSS, so the responsive.css rules won. All mobile/extra-small rules for the waterfall components table are now scoped to `.waterfall-analysis .cashflow-table …`, which bumps specificity to `(0,2,x)` and wins the cascade — the stacked-card layout with inline `data-label:` prefixes is back and there is no horizontal scroll.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca2b1d25-85e6-4deb-bbb8-496f40e27dd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

