### PR TITLE
Use Dutch number formatting on Vermogensontwikkeling chart

### DIFF
--- a/js/ui/charts.js
+++ b/js/ui/charts.js
@@ -151,6 +151,26 @@ export class ChartManager {
                     font: {
                         size: 16
                     }
+                },
+                tooltip: {
+                    ...this.defaultOptions.plugins.tooltip,
+                    callbacks: {
+                        label: function(context) {
+                            const label = context.dataset.label || '';
+                            const value = context.parsed.y;
+                            if (value === null || value === undefined) {
+                                return label;
+                            }
+                            const isPercent = context.dataset.yAxisID === 'y1';
+                            const formatted = isPercent
+                                ? new Intl.NumberFormat('nl-NL', {
+                                    minimumFractionDigits: 0,
+                                    maximumFractionDigits: 0
+                                }).format(value) + '%'
+                                : formatNumber(value);
+                            return label + ': ' + formatted;
+                        }
+                    }
                 }
             },
             scales: {
@@ -185,7 +205,10 @@ export class ChartManager {
                     },
                     ticks: {
                         callback: function(value) {
-                            return value + '%';
+                            return new Intl.NumberFormat('nl-NL', {
+                                minimumFractionDigits: 0,
+                                maximumFractionDigits: 0
+                            }).format(value) + '%';
                         }
                     }
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the basic calculator page, the "Vermogensontwikkeling over tijd" chart now formats numbers in the Dutch style and clearly distinguishes between euro amounts and percentages.

## Changes

- **Right Y-axis (ROI)**: Uses `Intl.NumberFormat('nl-NL')` with no decimals and a `%` suffix, so values like `12%` appear instead of `12.5%` and thousands use Dutch separators if ever large.
- **Tooltips**: Previously the main chart relied on Chart.js' default tooltip, which produces values like `1,000,000` (US-style, no unit). It now uses:
  - `formatNumber(value)` for euro-denominated datasets (Portfolio Waarde, Cash Reserve, Lening, Totaal Vermogen) which already uses `nl-NL` currency formatting → e.g. `€ 1.000.000` with Dutch thousands separators and no decimals.
  - Dutch number format with a `%` suffix and no decimals for the ROI dataset → e.g. `12%`.
- **Left Y-axis** was already using `formatNumber` (Dutch EUR, no decimals) — unchanged.

## Files

- `js/ui/charts.js` — updated `createMainOptions()` to add a tooltip label callback and to format the right-axis ticks in Dutch style with a `%` suffix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b114a48-5fbf-4616-9e3f-f5e40201aec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b114a48-5fbf-4616-9e3f-f5e40201aec5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

